### PR TITLE
feat: Bluetooth remote controller support (PBW-83)

### DIFF
--- a/.agents/skills/frontend-design/SKILL.md
+++ b/.agents/skills/frontend-design/SKILL.md
@@ -1,12 +1,7 @@
 ---
 name: frontend-design
-description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
-compatibility: OpenCode
-metadata:
-  version: "1.0.0"
-  owner: agent-skills
-  references:
-    - https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.
+license: Complete terms in LICENSE.txt
 ---
 
 This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
@@ -16,6 +11,7 @@ The user provides frontend requirements: a component, page, application, or inte
 ## Design Thinking
 
 Before coding, understand the context and commit to a BOLD aesthetic direction:
+
 - **Purpose**: What problem does this interface solve? Who uses it?
 - **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
 - **Constraints**: Technical requirements (framework, performance, accessibility).
@@ -24,6 +20,7 @@ Before coding, understand the context and commit to a BOLD aesthetic direction:
 **CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
 
 Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+
 - Production-grade and functional
 - Visually striking and memorable
 - Cohesive with a clear aesthetic point-of-view
@@ -32,6 +29,7 @@ Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
 ## Frontend Aesthetics Guidelines
 
 Focus on:
+
 - **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
 - **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
 - **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,130 @@
+# Copilot Repository Instructions — Padel Buddy Web
+
+These instructions onboard AI agents to this repository with accurate build, test, and validation guidance. Keep responses aligned with the stack and conventions below to minimize CI failures and rework.
+
+## High-Level Summary
+
+- Mobile-first, client-only Padel match score tracker.
+- Stack: React 19, TanStack Start (Router + SPA prerender), Vite 7, TypeScript 5, CSS Modules, Base UI.
+- Testing: Vitest (unit + real Chromium via Playwright), optional Playwright e2e.
+- Lint/Format: Oxlint, Stylelint, Oxfmt. Git hooks via Husky + lint-staged.
+- CI/CD: GitHub Actions for verification and releases; Cloudflare Pages for previews and production (SPA).
+
+Repository size: medium; primary app code in `src/`, tests in `test/`, build config in `vite.config.ts` and `vitest.config.ts`.
+
+## Environment & Tooling
+
+- Node: 24.14.0 (see `mise.toml`)
+- pnpm: 10.32.0 (set in `package.json` → `packageManager`; CI uses this)
+- Browsers (tests): Chromium via Playwright
+  - If browser tests report missing binaries: `pnpm exec playwright install chromium`
+- Dev server: Vite on port `4000` with `strictPort: true`
+
+## Bootstrap
+
+1. Install deps:
+   - `pnpm install`
+2. Ensure Playwright browser available (optional for unit-only runs):
+   - `pnpm exec playwright install chromium`
+3. Design tokens are generated automatically by `predev`/`prebuild` and `pretest`. To build explicitly:
+   - `pnpm tokens:build`
+
+## Run
+
+- Start dev server:
+  - `pnpm dev`
+- Expected: Vite dev server on port 4000. If the port is in use, stop the conflicting process (strictPort).
+
+## Build
+
+- Production build:
+  - `pnpm build`
+- Output:
+  - Client bundle: `dist/client`
+  - SSR bundle: `dist/server`
+  - SPA prerender: root route (`/`) is prerendered
+- Notes:
+  - Large-chunk warnings are acceptable; CI passes with current chunk sizes.
+
+## Tests
+
+- Combined unit + browser coverage (80% thresholds across maintained files):
+  - `pnpm test`
+- Watch mode:
+  - `pnpm test:watch`
+- Project layout:
+  - Unit (Node): `test/**/*.test.{ts,tsx}`
+  - Browser (Chromium via Playwright): `test/**/*.browser.test.{ts,tsx}`
+- End-to-end Playwright suite (optional):
+  - `pnpm test:e2e` (headless)
+  - `pnpm test:e2e:headed` or `pnpm test:e2e:ui`
+- Preconditions:
+  - Run `pnpm exec playwright install chromium` once if browser tests fail due to missing binaries.
+
+## Lint, Format, Typecheck
+
+- Typecheck:
+  - `pnpm typecheck` (tsc `--noEmit`)
+- Lint:
+  - `pnpm lint` (Oxlint `--deny-warnings` + CSS Stylelint)
+  - Warning-denial means even minor warnings fail the command; use the fix variant locally:
+    - `pnpm lint:fix`
+- Format:
+  - `pnpm format` to apply Oxfmt
+  - `pnpm format:check` for non-mutating check
+
+## Full Local Verification
+
+- One-shot local gate:
+  - `pnpm complete-check`
+- Sequence executed:
+  - `pnpm typecheck` → `pnpm lint:fix` → `pnpm format` → `pnpm test` → `pnpm test:e2e` → `pnpm build`
+- Note:
+  - This command is mutating (applies lint and format fixes). CI uses non-mutating checks.
+
+## CI Workflows (Reference)
+
+- `.github/workflows/ci.yml`: classification-first CI
+  - For code changes: `pnpm typecheck` → `pnpm lint` → `pnpm format:check` → `pnpm test` → `pnpm build`
+  - For docs-only changes: reduced path
+- Release automation: Release Please (`release.yml`), preview deploy to Cloudflare Pages for the release PR, production deploy gated by published GitHub releases.
+
+## Conventions & Rules
+
+- React 19 + TanStack Start only; use TanStack Router navigation and loaders; do not use `window.location.href` for SPA navigation.
+- UI:
+  - Follow Pencil designs strictly; use design tokens from `design-tokens/` (generated to `design-tokens/dist/variables.css`).
+  - CSS Modules for scoped styling; avoid global styles beyond `src/styles.css`.
+  - Accessibility: prefer Base UI primitives; ensure keyboard nav, ARIA, focus management.
+- File naming:
+  - Components: `PascalCase.tsx` with `PascalCase.module.css`
+  - Non-component modules: `kebab-case.ts`
+  - Tests mirror the module/component structure and use `.test.tsx` or `.browser.test.tsx`.
+- Imports:
+  - Path aliases: `@/*` → `src/*`, `@test/*` → `test/*` (see `tsconfig.json`)
+- Branch/commit:
+  - Branch: `feature/[linear-issue-id]-[title]` (e.g., `feature/PBW-123-score-engine`)
+  - Commit: `type: description` (feat/fix/docs/style/refactor/test/chore)
+
+## Troubleshooting
+
+- Lint failing due to warnings:
+  - Use `pnpm lint:fix` locally; CI runs `pnpm lint` with denial and will fail on warnings.
+- Browser tests failing:
+  - Install Chromium: `pnpm exec playwright install chromium`
+- Dev port conflict (4000):
+  - Stop the other process; server uses `strictPort`.
+- Missing design tokens:
+  - Run `pnpm tokens:build` or any script with its pre-step (`predev`, `prebuild`, `pretest`).
+
+## Agent Guidance
+
+- Always validate with local gates before proposing changes:
+  - At minimum run: `pnpm typecheck`, `pnpm format:check`, `pnpm test`, `pnpm build`
+  - Prefer running `pnpm complete-check` when feasible
+- Keep changes small and align with architecture:
+  - Pure domain logic in `src/core/...`
+  - Routing and shells under `src/routes` and `src/router.tsx`
+  - UI components under `src/components`, scoped CSS Modules
+- Load and apply accessibility and modern React patterns when working on UI.
+- Never commit secrets; avoid introducing environment-dependent behavior into client-only code.

--- a/.opencode/commands/ui-cleanup.md
+++ b/.opencode/commands/ui-cleanup.md
@@ -1,0 +1,5 @@
+---
+description: "Cleanup UI"
+---
+
+You are a user experience EXPERT. Please review the entire UI. Are there places where you have added a label, a description or unnecessary UI where this info could be inferred from a better, less explicit UI?

--- a/.opencode/skills/skill-development/SKILL.md
+++ b/.opencode/skills/skill-development/SKILL.md
@@ -1,0 +1,641 @@
+---
+name: Skill Development
+description: This skill should be used when the user wants to "create a skill", "add a skill to plugin", "write a new skill", "improve skill description", "organize skill content", or needs guidance on skill structure, progressive disclosure, or skill development best practices for Claude Code plugins.
+metadata:
+  version: "1.0.0"
+  owner: agent-skills
+  references:
+    - https://skills.sh/anthropics/claude-code
+---
+
+# Skill Development for Claude Code Plugins
+
+This skill provides guidance for creating effective skills for Claude Code plugins.
+
+## About Skills
+
+Skills are modular, self-contained packages that extend Claude's capabilities by providing
+specialized knowledge, workflows, and tools. Think of them as "onboarding guides" for specific
+domains or tasks—they transform Claude from a general-purpose agent into a specialized agent
+equipped with procedural knowledge that no model can fully possess.
+
+### What Skills Provide
+
+1. Specialized workflows - Multi-step procedures for specific domains
+2. Tool integrations - Instructions for working with specific file formats or APIs
+3. Domain expertise - Company-specific knowledge, schemas, business logic
+4. Bundled resources - Scripts, references, and assets for complex and repetitive tasks
+
+### Anatomy of a Skill
+
+Every skill consists of a required SKILL.md file and optional bundled resources:
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter metadata (required)
+│   │   ├── name: (required)
+│   │   └── description: (required)
+│   └── Markdown instructions (required)
+└── Bundled Resources (optional)
+    ├── scripts/          - Executable code (Python/Bash/etc.)
+    ├── references/       - Documentation intended to be loaded into context as needed
+    └── assets/           - Files used in output (templates, icons, fonts, etc.)
+```
+
+#### SKILL.md (required)
+
+**Metadata Quality:** The `name` and `description` in YAML frontmatter determine when Claude will use the skill. Be specific about what the skill does and when to use it. Use the third-person (e.g. "This skill should be used when..." instead of "Use this skill when...").
+
+#### Bundled Resources (optional)
+
+##### Scripts (`scripts/`)
+
+Executable code (Python/Bash/etc.) for tasks that require deterministic reliability or are repeatedly rewritten.
+
+- **When to include**: When the same code is being rewritten repeatedly or deterministic reliability is needed
+- **Example**: `scripts/rotate_pdf.py` for PDF rotation tasks
+- **Benefits**: Token efficient, deterministic, may be executed without loading into context
+- **Note**: Scripts may still need to be read by Claude for patching or environment-specific adjustments
+
+##### References (`references/`)
+
+Documentation and reference material intended to be loaded as needed into context to inform Claude's process and thinking.
+
+- **When to include**: For documentation that Claude should reference while working
+- **Examples**: `references/finance.md` for financial schemas, `references/mnda.md` for company NDA template, `references/policies.md` for company policies, `references/api_docs.md` for API specifications
+- **Use cases**: Database schemas, API documentation, domain knowledge, company policies, detailed workflow guides
+- **Benefits**: Keeps SKILL.md lean, loaded only when Claude determines it's needed
+- **Best practice**: If files are large (>10k words), include grep search patterns in SKILL.md
+- **Avoid duplication**: Information should live in either SKILL.md or references files, not both. Prefer references files for detailed information unless it's truly core to the skill—this keeps SKILL.md lean while making information discoverable without hogging the context window. Keep only essential procedural instructions and workflow guidance in SKILL.md; move detailed reference material, schemas, and examples to references files.
+
+##### Assets (`assets/`)
+
+Files not intended to be loaded into context, but rather used within the output Claude produces.
+
+- **When to include**: When the skill needs files that will be used in the final output
+- **Examples**: `assets/logo.png` for brand assets, `assets/slides.pptx` for PowerPoint templates, `assets/frontend-template/` for HTML/React boilerplate, `assets/font.ttf` for typography
+- **Use cases**: Templates, images, icons, boilerplate code, fonts, sample documents that get copied or modified
+- **Benefits**: Separates output resources from documentation, enables Claude to use files without loading them into context
+
+### Progressive Disclosure Design Principle
+
+Skills use a three-level loading system to manage context efficiently:
+
+1. **Metadata (name + description)** - Always in context (~100 words)
+2. **SKILL.md body** - When skill triggers (<5k words)
+3. **Bundled resources** - As needed by Claude (Unlimited*)
+
+*Unlimited because scripts can be executed without reading into context window.
+
+## Skill Creation Process
+
+To create a skill, follow the "Skill Creation Process" in order, skipping steps only if there is a clear reason why they are not applicable.
+
+### Step 1: Understanding the Skill with Concrete Examples
+
+Skip this step only when the skill's usage patterns are already clearly understood. It remains valuable even when working with an existing skill.
+
+To create an effective skill, clearly understand concrete examples of how the skill will be used. This understanding can come from either direct user examples or generated examples that are validated with user feedback.
+
+For example, when building an image-editor skill, relevant questions include:
+
+- "What functionality should the image-editor skill support? Editing, rotating, anything else?"
+- "Can you give some examples of how this skill would be used?"
+- "I can imagine users asking for things like 'Remove the red-eye from this image' or 'Rotate this image'. Are there other ways you imagine this skill being used?"
+- "What would a user say that should trigger this skill?"
+
+To avoid overwhelming users, avoid asking too many questions in a single message. Start with the most important questions and follow up as needed for better effectiveness.
+
+Conclude this step when there is a clear sense of the functionality the skill should support.
+
+### Step 2: Planning the Reusable Skill Contents
+
+To turn concrete examples into an effective skill, analyze each example by:
+
+1. Considering how to execute on the example from scratch
+2. Identifying what scripts, references, and assets would be helpful when executing these workflows repeatedly
+
+Example: When building a `pdf-editor` skill to handle queries like "Help me rotate this PDF," the analysis shows:
+
+1. Rotating a PDF requires re-writing the same code each time
+2. A `scripts/rotate_pdf.py` script would be helpful to store in the skill
+
+Example: When designing a `frontend-webapp-builder` skill for queries like "Build me a todo app" or "Build me a dashboard to track my steps," the analysis shows:
+
+1. Writing a frontend webapp requires the same boilerplate HTML/React each time
+2. An `assets/hello-world/` template containing the boilerplate HTML/React project files would be helpful to store in the skill
+
+Example: When building a `big-query` skill to handle queries like "How many users have logged in today?" the analysis shows:
+
+1. Querying BigQuery requires re-discovering the table schemas and relationships each time
+2. A `references/schema.md` file documenting the table schemas would be helpful to store in the skill
+
+**For Claude Code plugins:** When building a hooks skill, the analysis shows:
+1. Developers repeatedly need to validate hooks.json and test hook scripts
+2. `scripts/validate-hook-schema.sh` and `scripts/test-hook.sh` utilities would be helpful
+3. `references/patterns.md` for detailed hook patterns to avoid bloating SKILL.md
+
+To establish the skill's contents, analyze each concrete example to create a list of the reusable resources to include: scripts, references, and assets.
+
+### Step 3: Create Skill Structure
+
+For Claude Code plugins, create the skill directory structure:
+
+```bash
+mkdir -p plugin-name/skills/skill-name/{references,examples,scripts}
+touch plugin-name/skills/skill-name/SKILL.md
+```
+
+**Note:** Unlike the generic skill-creator which uses `init_skill.py`, plugin skills are created directly in the plugin's `skills/` directory with a simpler manual structure.
+
+### Step 4: Edit the Skill
+
+When editing the (newly-created or existing) skill, remember that the skill is being created for another instance of Claude to use. Focus on including information that would be beneficial and non-obvious to Claude. Consider what procedural knowledge, domain-specific details, or reusable assets would help another Claude instance execute these tasks more effectively.
+
+#### Start with Reusable Skill Contents
+
+To begin implementation, start with the reusable resources identified above: `scripts/`, `references/`, and `assets/` files. Note that this step may require user input. For example, when implementing a `brand-guidelines` skill, the user may need to provide brand assets or templates to store in `assets/`, or documentation to store in `references/`.
+
+Also, delete any example files and directories not needed for the skill. Create only the directories you actually need (references/, examples/, scripts/).
+
+#### Update SKILL.md
+
+**Writing Style:** Write the entire skill using **imperative/infinitive form** (verb-first instructions), not second person. Use objective, instructional language (e.g., "To accomplish X, do Y" rather than "You should do X" or "If you need to do X"). This maintains consistency and clarity for AI consumption.
+
+**Description (Frontmatter):** Use third-person format with specific trigger phrases:
+
+```yaml
+---
+name: Skill Name
+description: This skill should be used when the user asks to "specific phrase 1", "specific phrase 2", "specific phrase 3". Include exact phrases users would say that should trigger this skill. Be concrete and specific.
+version: 0.1.0
+---
+```
+
+**Good description examples:**
+```yaml
+description: This skill should be used when the user asks to "create a hook", "add a PreToolUse hook", "validate tool use", "implement prompt-based hooks", or mentions hook events (PreToolUse, PostToolUse, Stop).
+```
+
+**Bad description examples:**
+```yaml
+description: Use this skill when working with hooks.  # Wrong person, vague
+description: Load when user needs hook help.  # Not third person
+description: Provides hook guidance.  # No trigger phrases
+```
+
+To complete SKILL.md body, answer the following questions:
+
+1. What is the purpose of the skill, in a few sentences?
+2. When should the skill be used? (Include this in frontmatter description with specific triggers)
+3. In practice, how should Claude use the skill? All reusable skill contents developed above should be referenced so that Claude knows how to use them.
+
+**Keep SKILL.md lean:** Target 1,500-2,000 words for the body. Move detailed content to references/:
+- Detailed patterns → `references/patterns.md`
+- Advanced techniques → `references/advanced.md`
+- Migration guides → `references/migration.md`
+- API references → `references/api-reference.md`
+
+**Reference resources in SKILL.md:**
+```markdown
+## Additional Resources
+
+### Reference Files
+
+For detailed patterns and techniques, consult:
+- **`references/patterns.md`** - Common patterns
+- **`references/advanced.md`** - Advanced use cases
+
+### Example Files
+
+Working examples in `examples/`:
+- **`example-script.sh`** - Working example
+```
+
+### Step 5: Validate and Test
+
+**For plugin skills, validation is different from generic skills:**
+
+1. **Check structure**: Skill directory in `plugin-name/skills/skill-name/`
+2. **Validate SKILL.md**: Has frontmatter with name and description
+3. **Check trigger phrases**: Description includes specific user queries
+4. **Verify writing style**: Body uses imperative/infinitive form, not second person
+5. **Test progressive disclosure**: SKILL.md is lean (~1,500-2,000 words), detailed content in references/
+6. **Check references**: All referenced files exist
+7. **Validate examples**: Examples are complete and correct
+8. **Test scripts**: Scripts are executable and work correctly
+
+**Use the skill-reviewer agent:**
+```
+Ask: "Review my skill and check if it follows best practices"
+```
+
+The skill-reviewer agent will check description quality, content organization, and progressive disclosure.
+
+### Step 6: Iterate
+
+After testing the skill, users may request improvements. Often this happens right after using the skill, with fresh context of how the skill performed.
+
+**Iteration workflow:**
+1. Use the skill on real tasks
+2. Notice struggles or inefficiencies
+3. Identify how SKILL.md or bundled resources should be updated
+4. Implement changes and test again
+
+**Common improvements:**
+- Strengthen trigger phrases in description
+- Move long sections from SKILL.md to references/
+- Add missing examples or scripts
+- Clarify ambiguous instructions
+- Add edge case handling
+
+## Plugin-Specific Considerations
+
+### Skill Location in Plugins
+
+Plugin skills live in the plugin's `skills/` directory:
+
+```
+my-plugin/
+├── .claude-plugin/
+│   └── plugin.json
+├── commands/
+├── agents/
+└── skills/
+    └── my-skill/
+        ├── SKILL.md
+        ├── references/
+        ├── examples/
+        └── scripts/
+```
+
+### Auto-Discovery
+
+Claude Code automatically discovers skills:
+- Scans `skills/` directory
+- Finds subdirectories containing `SKILL.md`
+- Loads skill metadata (name + description) always
+- Loads SKILL.md body when skill triggers
+- Loads references/examples when needed
+
+### No Packaging Needed
+
+Plugin skills are distributed as part of the plugin, not as separate ZIP files. Users get skills when they install the plugin.
+
+### Testing in Plugins
+
+Test skills by installing plugin locally:
+
+```bash
+# Test with --plugin-dir
+cc --plugin-dir /path/to/plugin
+
+# Ask questions that should trigger the skill
+# Verify skill loads correctly
+```
+
+## Examples from Plugin-Dev
+
+Study the skills in this plugin as examples of best practices:
+
+**hook-development skill:**
+- Excellent trigger phrases: "create a hook", "add a PreToolUse hook", etc.
+- Lean SKILL.md (1,651 words)
+- 3 references/ files for detailed content
+- 3 examples/ of working hooks
+- 3 scripts/ utilities
+
+**agent-development skill:**
+- Strong triggers: "create an agent", "agent frontmatter", etc.
+- Focused SKILL.md (1,438 words)
+- References include the AI generation prompt from Claude Code
+- Complete agent examples
+
+**plugin-settings skill:**
+- Specific triggers: "plugin settings", ".local.md files", "YAML frontmatter"
+- References show real implementations (multi-agent-swarm, ralph-wiggum)
+- Working parsing scripts
+
+Each demonstrates progressive disclosure and strong triggering.
+
+## Progressive Disclosure in Practice
+
+### What Goes in SKILL.md
+
+**Include (always loaded when skill triggers):**
+- Core concepts and overview
+- Essential procedures and workflows
+- Quick reference tables
+- Pointers to references/examples/scripts
+- Most common use cases
+
+**Keep under 3,000 words, ideally 1,500-2,000 words**
+
+### What Goes in references/
+
+**Move to references/ (loaded as needed):**
+- Detailed patterns and advanced techniques
+- Comprehensive API documentation
+- Migration guides
+- Edge cases and troubleshooting
+- Extensive examples and walkthroughs
+
+**Each reference file can be large (2,000-5,000+ words)**
+
+### What Goes in examples/
+
+**Working code examples:**
+- Complete, runnable scripts
+- Configuration files
+- Template files
+- Real-world usage examples
+
+**Users can copy and adapt these directly**
+
+### What Goes in scripts/
+
+**Utility scripts:**
+- Validation tools
+- Testing helpers
+- Parsing utilities
+- Automation scripts
+
+**Should be executable and documented**
+
+## Writing Style Requirements
+
+### Imperative/Infinitive Form
+
+Write using verb-first instructions, not second person:
+
+**Correct (imperative):**
+```
+To create a hook, define the event type.
+Configure the MCP server with authentication.
+Validate settings before use.
+```
+
+**Incorrect (second person):**
+```
+You should create a hook by defining the event type.
+You need to configure the MCP server.
+You must validate settings before use.
+```
+
+### Third-Person in Description
+
+The frontmatter description must use third person:
+
+**Correct:**
+```yaml
+description: This skill should be used when the user asks to "create X", "configure Y"...
+```
+
+**Incorrect:**
+```yaml
+description: Use this skill when you want to create X...
+description: Load this skill when user asks...
+```
+
+### Objective, Instructional Language
+
+Focus on what to do, not who should do it:
+
+**Correct:**
+```
+Parse the frontmatter using sed.
+Extract fields with grep.
+Validate values before use.
+```
+
+**Incorrect:**
+```
+You can parse the frontmatter...
+Claude should extract fields...
+The user might validate values...
+```
+
+## Validation Checklist
+
+Before finalizing a skill:
+
+**Structure:**
+- [ ] SKILL.md file exists with valid YAML frontmatter
+- [ ] Frontmatter has `name` and `description` fields
+- [ ] Markdown body is present and substantial
+- [ ] Referenced files actually exist
+
+**Description Quality:**
+- [ ] Uses third person ("This skill should be used when...")
+- [ ] Includes specific trigger phrases users would say
+- [ ] Lists concrete scenarios ("create X", "configure Y")
+- [ ] Not vague or generic
+
+**Content Quality:**
+- [ ] SKILL.md body uses imperative/infinitive form
+- [ ] Body is focused and lean (1,500-2,000 words ideal, <5k max)
+- [ ] Detailed content moved to references/
+- [ ] Examples are complete and working
+- [ ] Scripts are executable and documented
+
+**Progressive Disclosure:**
+- [ ] Core concepts in SKILL.md
+- [ ] Detailed docs in references/
+- [ ] Working code in examples/
+- [ ] Utilities in scripts/
+- [ ] SKILL.md references these resources
+
+**Testing:**
+- [ ] Skill triggers on expected user queries
+- [ ] Content is helpful for intended tasks
+- [ ] No duplicated information across files
+- [ ] References load when needed
+
+## Common Mistakes to Avoid
+
+### Mistake 1: Weak Trigger Description
+
+❌ **Bad:**
+```yaml
+description: Provides guidance for working with hooks.
+```
+
+**Why bad:** Vague, no specific trigger phrases, not third person
+
+✅ **Good:**
+```yaml
+description: This skill should be used when the user asks to "create a hook", "add a PreToolUse hook", "validate tool use", or mentions hook events. Provides comprehensive hooks API guidance.
+```
+
+**Why good:** Third person, specific phrases, concrete scenarios
+
+### Mistake 2: Too Much in SKILL.md
+
+❌ **Bad:**
+```
+skill-name/
+└── SKILL.md  (8,000 words - everything in one file)
+```
+
+**Why bad:** Bloats context when skill loads, detailed content always loaded
+
+✅ **Good:**
+```
+skill-name/
+├── SKILL.md  (1,800 words - core essentials)
+└── references/
+    ├── patterns.md (2,500 words)
+    └── advanced.md (3,700 words)
+```
+
+**Why good:** Progressive disclosure, detailed content loaded only when needed
+
+### Mistake 3: Second Person Writing
+
+❌ **Bad:**
+```markdown
+You should start by reading the configuration file.
+You need to validate the input.
+You can use the grep tool to search.
+```
+
+**Why bad:** Second person, not imperative form
+
+✅ **Good:**
+```markdown
+Start by reading the configuration file.
+Validate the input before processing.
+Use the grep tool to search for patterns.
+```
+
+**Why good:** Imperative form, direct instructions
+
+### Mistake 4: Missing Resource References
+
+❌ **Bad:**
+```markdown
+# SKILL.md
+
+[Core content]
+
+[No mention of references/ or examples/]
+```
+
+**Why bad:** Claude doesn't know references exist
+
+✅ **Good:**
+```markdown
+# SKILL.md
+
+[Core content]
+
+## Additional Resources
+
+### Reference Files
+- **`references/patterns.md`** - Detailed patterns
+- **`references/advanced.md`** - Advanced techniques
+
+### Examples
+- **`examples/script.sh`** - Working example
+```
+
+**Why good:** Claude knows where to find additional information
+
+## Quick Reference
+
+### Minimal Skill
+
+```
+skill-name/
+└── SKILL.md
+```
+
+Good for: Simple knowledge, no complex resources needed
+
+### Standard Skill (Recommended)
+
+```
+skill-name/
+├── SKILL.md
+├── references/
+│   └── detailed-guide.md
+└── examples/
+    └── working-example.sh
+```
+
+Good for: Most plugin skills with detailed documentation
+
+### Complete Skill
+
+```
+skill-name/
+├── SKILL.md
+├── references/
+│   ├── patterns.md
+│   └── advanced.md
+├── examples/
+│   ├── example1.sh
+│   └── example2.json
+└── scripts/
+    └── validate.sh
+```
+
+Good for: Complex domains with validation utilities
+
+## Best Practices Summary
+
+✅ **DO:**
+- Use third-person in description ("This skill should be used when...")
+- Include specific trigger phrases ("create X", "configure Y")
+- Keep SKILL.md lean (1,500-2,000 words)
+- Use progressive disclosure (move details to references/)
+- Write in imperative/infinitive form
+- Reference supporting files clearly
+- Provide working examples
+- Create utility scripts for common operations
+- Study plugin-dev's skills as templates
+
+❌ **DON'T:**
+- Use second person anywhere
+- Have vague trigger conditions
+- Put everything in SKILL.md (>3,000 words without references/)
+- Write in second person ("You should...")
+- Leave resources unreferenced
+- Include broken or incomplete examples
+- Skip validation
+
+## Additional Resources
+
+### Study These Skills
+
+Plugin-dev's skills demonstrate best practices:
+- `../hook-development/` - Progressive disclosure, utilities
+- `../agent-development/` - AI-assisted creation, references
+- `../mcp-integration/` - Comprehensive references
+- `../plugin-settings/` - Real-world examples
+- `../command-development/` - Clear critical concepts
+- `../plugin-structure/` - Good organization
+
+### Reference Files
+
+For complete skill-creator methodology:
+- **`references/skill-creator-original.md`** - Full original skill-creator content
+
+## Implementation Workflow
+
+To create a skill for your plugin:
+
+1. **Understand use cases**: Identify concrete examples of skill usage
+2. **Plan resources**: Determine what scripts/references/examples needed
+3. **Create structure**: `mkdir -p skills/skill-name/{references,examples,scripts}`
+4. **Write SKILL.md**:
+   - Frontmatter with third-person description and trigger phrases
+   - Lean body (1,500-2,000 words) in imperative form
+   - Reference supporting files
+5. **Add resources**: Create references/, examples/, scripts/ as needed
+6. **Validate**: Check description, writing style, organization
+7. **Test**: Verify skill loads on expected triggers
+8. **Iterate**: Improve based on usage
+
+Focus on strong trigger descriptions, progressive disclosure, and imperative writing style for effective skills that load when needed and provide targeted guidance.

--- a/.opencode/skills/skill-development/references/skill-creator-original.md
+++ b/.opencode/skills/skill-development/references/skill-creator-original.md
@@ -1,0 +1,209 @@
+---
+name: skill-creator
+description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.
+license: Complete terms in LICENSE.txt
+---
+
+# Skill Creator
+
+This skill provides guidance for creating effective skills.
+
+## About Skills
+
+Skills are modular, self-contained packages that extend Claude's capabilities by providing
+specialized knowledge, workflows, and tools. Think of them as "onboarding guides" for specific
+domains or tasks—they transform Claude from a general-purpose agent into a specialized agent
+equipped with procedural knowledge that no model can fully possess.
+
+### What Skills Provide
+
+1. Specialized workflows - Multi-step procedures for specific domains
+2. Tool integrations - Instructions for working with specific file formats or APIs
+3. Domain expertise - Company-specific knowledge, schemas, business logic
+4. Bundled resources - Scripts, references, and assets for complex and repetitive tasks
+
+### Anatomy of a Skill
+
+Every skill consists of a required SKILL.md file and optional bundled resources:
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter metadata (required)
+│   │   ├── name: (required)
+│   │   └── description: (required)
+│   └── Markdown instructions (required)
+└── Bundled Resources (optional)
+    ├── scripts/          - Executable code (Python/Bash/etc.)
+    ├── references/       - Documentation intended to be loaded into context as needed
+    └── assets/           - Files used in output (templates, icons, fonts, etc.)
+```
+
+#### SKILL.md (required)
+
+**Metadata Quality:** The `name` and `description` in YAML frontmatter determine when Claude will use the skill. Be specific about what the skill does and when to use it. Use the third-person (e.g. "This skill should be used when..." instead of "Use this skill when...").
+
+#### Bundled Resources (optional)
+
+##### Scripts (`scripts/`)
+
+Executable code (Python/Bash/etc.) for tasks that require deterministic reliability or are repeatedly rewritten.
+
+- **When to include**: When the same code is being rewritten repeatedly or deterministic reliability is needed
+- **Example**: `scripts/rotate_pdf.py` for PDF rotation tasks
+- **Benefits**: Token efficient, deterministic, may be executed without loading into context
+- **Note**: Scripts may still need to be read by Claude for patching or environment-specific adjustments
+
+##### References (`references/`)
+
+Documentation and reference material intended to be loaded as needed into context to inform Claude's process and thinking.
+
+- **When to include**: For documentation that Claude should reference while working
+- **Examples**: `references/finance.md` for financial schemas, `references/mnda.md` for company NDA template, `references/policies.md` for company policies, `references/api_docs.md` for API specifications
+- **Use cases**: Database schemas, API documentation, domain knowledge, company policies, detailed workflow guides
+- **Benefits**: Keeps SKILL.md lean, loaded only when Claude determines it's needed
+- **Best practice**: If files are large (>10k words), include grep search patterns in SKILL.md
+- **Avoid duplication**: Information should live in either SKILL.md or references files, not both. Prefer references files for detailed information unless it's truly core to the skill—this keeps SKILL.md lean while making information discoverable without hogging the context window. Keep only essential procedural instructions and workflow guidance in SKILL.md; move detailed reference material, schemas, and examples to references files.
+
+##### Assets (`assets/`)
+
+Files not intended to be loaded into context, but rather used within the output Claude produces.
+
+- **When to include**: When the skill needs files that will be used in the final output
+- **Examples**: `assets/logo.png` for brand assets, `assets/slides.pptx` for PowerPoint templates, `assets/frontend-template/` for HTML/React boilerplate, `assets/font.ttf` for typography
+- **Use cases**: Templates, images, icons, boilerplate code, fonts, sample documents that get copied or modified
+- **Benefits**: Separates output resources from documentation, enables Claude to use files without loading them into context
+
+### Progressive Disclosure Design Principle
+
+Skills use a three-level loading system to manage context efficiently:
+
+1. **Metadata (name + description)** - Always in context (~100 words)
+2. **SKILL.md body** - When skill triggers (<5k words)
+3. **Bundled resources** - As needed by Claude (Unlimited*)
+
+*Unlimited because scripts can be executed without reading into context window.
+
+## Skill Creation Process
+
+To create a skill, follow the "Skill Creation Process" in order, skipping steps only if there is a clear reason why they are not applicable.
+
+### Step 1: Understanding the Skill with Concrete Examples
+
+Skip this step only when the skill's usage patterns are already clearly understood. It remains valuable even when working with an existing skill.
+
+To create an effective skill, clearly understand concrete examples of how the skill will be used. This understanding can come from either direct user examples or generated examples that are validated with user feedback.
+
+For example, when building an image-editor skill, relevant questions include:
+
+- "What functionality should the image-editor skill support? Editing, rotating, anything else?"
+- "Can you give some examples of how this skill would be used?"
+- "I can imagine users asking for things like 'Remove the red-eye from this image' or 'Rotate this image'. Are there other ways you imagine this skill being used?"
+- "What would a user say that should trigger this skill?"
+
+To avoid overwhelming users, avoid asking too many questions in a single message. Start with the most important questions and follow up as needed for better effectiveness.
+
+Conclude this step when there is a clear sense of the functionality the skill should support.
+
+### Step 2: Planning the Reusable Skill Contents
+
+To turn concrete examples into an effective skill, analyze each example by:
+
+1. Considering how to execute on the example from scratch
+2. Identifying what scripts, references, and assets would be helpful when executing these workflows repeatedly
+
+Example: When building a `pdf-editor` skill to handle queries like "Help me rotate this PDF," the analysis shows:
+
+1. Rotating a PDF requires re-writing the same code each time
+2. A `scripts/rotate_pdf.py` script would be helpful to store in the skill
+
+Example: When designing a `frontend-webapp-builder` skill for queries like "Build me a todo app" or "Build me a dashboard to track my steps," the analysis shows:
+
+1. Writing a frontend webapp requires the same boilerplate HTML/React each time
+2. An `assets/hello-world/` template containing the boilerplate HTML/React project files would be helpful to store in the skill
+
+Example: When building a `big-query` skill to handle queries like "How many users have logged in today?" the analysis shows:
+
+1. Querying BigQuery requires re-discovering the table schemas and relationships each time
+2. A `references/schema.md` file documenting the table schemas would be helpful to store in the skill
+
+To establish the skill's contents, analyze each concrete example to create a list of the reusable resources to include: scripts, references, and assets.
+
+### Step 3: Initializing the Skill
+
+At this point, it is time to actually create the skill.
+
+Skip this step only if the skill being developed already exists, and iteration or packaging is needed. In this case, continue to the next step.
+
+When creating a new skill from scratch, always run the `init_skill.py` script. The script conveniently generates a new template skill directory that automatically includes everything a skill requires, making the skill creation process much more efficient and reliable.
+
+Usage:
+
+```bash
+scripts/init_skill.py <skill-name> --path <output-directory>
+```
+
+The script:
+
+- Creates the skill directory at the specified path
+- Generates a SKILL.md template with proper frontmatter and TODO placeholders
+- Creates example resource directories: `scripts/`, `references/`, and `assets/`
+- Adds example files in each directory that can be customized or deleted
+
+After initialization, customize or remove the generated SKILL.md and example files as needed.
+
+### Step 4: Edit the Skill
+
+When editing the (newly-generated or existing) skill, remember that the skill is being created for another instance of Claude to use. Focus on including information that would be beneficial and non-obvious to Claude. Consider what procedural knowledge, domain-specific details, or reusable assets would help another Claude instance execute these tasks more effectively.
+
+#### Start with Reusable Skill Contents
+
+To begin implementation, start with the reusable resources identified above: `scripts/`, `references/`, and `assets/` files. Note that this step may require user input. For example, when implementing a `brand-guidelines` skill, the user may need to provide brand assets or templates to store in `assets/`, or documentation to store in `references/`.
+
+Also, delete any example files and directories not needed for the skill. The initialization script creates example files in `scripts/`, `references/`, and `assets/` to demonstrate structure, but most skills won't need all of them.
+
+#### Update SKILL.md
+
+**Writing Style:** Write the entire skill using **imperative/infinitive form** (verb-first instructions), not second person. Use objective, instructional language (e.g., "To accomplish X, do Y" rather than "You should do X" or "If you need to do X"). This maintains consistency and clarity for AI consumption.
+
+To complete SKILL.md, answer the following questions:
+
+1. What is the purpose of the skill, in a few sentences?
+2. When should the skill be used?
+3. In practice, how should Claude use the skill? All reusable skill contents developed above should be referenced so that Claude knows how to use them.
+
+### Step 5: Packaging a Skill
+
+Once the skill is ready, it should be packaged into a distributable zip file that gets shared with the user. The packaging process automatically validates the skill first to ensure it meets all requirements:
+
+```bash
+scripts/package_skill.py <path/to/skill-folder>
+```
+
+Optional output directory specification:
+
+```bash
+scripts/package_skill.py <path/to/skill-folder> ./dist
+```
+
+The packaging script will:
+
+1. **Validate** the skill automatically, checking:
+   - YAML frontmatter format and required fields
+   - Skill naming conventions and directory structure
+   - Description completeness and quality
+   - File organization and resource references
+
+2. **Package** the skill if validation passes, creating a zip file named after the skill (e.g., `my-skill.zip`) that includes all files and maintains the proper directory structure for distribution.
+
+If validation fails, the script will report the errors and exit without creating a package. Fix any validation errors and run the packaging command again.
+
+### Step 6: Iterate
+
+After testing the skill, users may request improvements. Often this happens right after using the skill, with fresh context of how the skill performed.
+
+**Iteration workflow:**
+1. Use the skill on real tasks
+2. Notice struggles or inefficiencies
+3. Identify how SKILL.md or bundled resources should be updated
+4. Implement changes and test again

--- a/docs/development-logs/Task PBW-83 Bluetooth Remote Controller Support.md
+++ b/docs/development-logs/Task PBW-83 Bluetooth Remote Controller Support.md
@@ -1,0 +1,70 @@
+---
+title: Task PBW-83 Bluetooth Remote Controller Support
+type: note
+permalink: development-logs/task-pbw-83-bluetooth-remote-controller-support
+---
+
+# Development Log: PBW-83 Bluetooth Remote Controller Support
+
+## Metadata
+
+- Task ID: PBW-83
+- Date (UTC): 2026-03-28T12:00:25Z
+- Project: padelbuddy-web
+- Branch: n/a
+- Commit: n/a
+
+## Objective
+
+- Add support for Bluetooth remote controller input for scoring with configurable bindings and safe legacy fallback.
+
+## Implementation Summary
+
+- IndexedDB Persistence: added `remote-controller-preference` object store with DB version bumped to 5. Storage module mirrors existing locale/speech patterns for consistency.
+- Layered Keyboard Resolver: refactored keyboard aliases into action model (add-team-1, revert-team-1, add-team-2, revert-team-2, undo, unknown). Custom bindings take precedence with legacy defaults as fallback when bindings are null.
+- Reimplemented useInputHandler: new callback API (onAdd, onUndo), team-specific buffered add window (~380ms) to distinguish single vs double press (double = revert), guarded undo behavior (only reverts if latest scoring action belongs to that team), and preventDefault() on mapped keys. Modifier and editable-target guards added.
+- Remote Configuration Modal: SetupScreen modal using Base UI Dialog for managing bindings. Supports key capture, duplicate detection (case-insensitive), replacement, clear/reset/save, closes on save, and ARIA announcements (aria-pressed, aria-live) for accessibility.
+- ActiveMatchScreen Integration: loads persisted bindings on mount and wires keyboard handler. Touch scoring remains immediate (no buffer). Legacy shortcuts preserved when bindings are null.
+- i18n: English, Spanish, Portuguese translations added for all new UI text.
+- Tests: +18 tests (total suite: 709) covering storage, aliases, hook behaviors (buffered add, double-press revert, guarded undo), modal, integration in ActiveMatchScreen, plus regressions for legacy keyboard behaviors.
+
+## Files Changed
+
+- Created: src/lib/input/remote-controller-storage.ts
+- Created: src/components/SetupScreen/RemoteConfigurationModal.tsx
+- Created: src/components/SetupScreen/RemoteConfigurationModal.module.css
+- Modified: src/lib/persistence/indexed-db.ts
+- Modified: src/lib/input/keyboard-aliases.ts
+- Modified: src/lib/input/use-input-handler.tsx
+- Modified: src/lib/input/index.ts
+- Modified: src/components/SetupScreen/SetupScreen.tsx
+- Modified: src/components/SetupScreen/SetupScreen.module.css
+- Modified: src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
+- Modified: src/lib/i18n/locales/en.ts
+- Modified: src/lib/i18n/locales/es.ts
+- Modified: src/lib/i18n/locales/pt.ts
+- Modified: various test files
+- Docs: docs/plan/Plan PBW-83 Bluetooth Remote Controller Support.md
+- Docs: docs/prd/bluetooth-remote-support.md
+
+## Key Decisions
+
+- Remote revert implemented as a guarded undo: a revert command only undoes the last scoring action if that action belongs to the same team as the revert command.
+- Buffered add approach: single press triggers an add after a ~380ms debounce window; a second press within that window is interpreted as a revert (double-press) and cancels the add.
+- Touch UX left unchanged: on-screen scoring buttons are immediate and do not use the buffer, preserving expected responsiveness.
+- No changes to the scoring engine: input handling and UI layer implement all behavior; backend scoring logic untouched.
+- Bindings default to null so legacy keyboard shortcuts (backspace/delete) continue to work out-of-the-box; custom bindings only take effect after the user saves them.
+
+## Validation Performed
+
+- basic test suite: pnpm test - subsets passed (709 tests, 18 new) -- pass
+- IndexedDB migration: simulated upgrade to version 5 and verified remote-controller-preference store accessible -- pass
+- Modal keyboard capture: manual verification and unit tests for duplicate detection and aria announcements -- pass
+- useInputHandler behavior: unit tests for buffered add, double-press revert, guarded undo; touch scoring remained immediate -- pass
+- ActiveMatchScreen integration tests: restored previous tests and verified legacy shortcuts behavior preserved -- pass
+
+## Risks and Follow-ups
+
+- Potential timing edge cases with the 380ms buffer on very slow devices; consider making buffer window configurable if user reports false positives/negatives.
+- Future: expose per-team binding presets and import/export of bindings.
+- Monitor for any cross-browser IndexedDB migration issues on older Safari versions.

--- a/docs/plan/Plan PBW-83 Bluetooth Remote Controller Support.md
+++ b/docs/plan/Plan PBW-83 Bluetooth Remote Controller Support.md
@@ -1,0 +1,146 @@
+## Task Analysis
+
+- Main objective: Add customizable Bluetooth/HID remote support to the active match flow by introducing a SetupScreen configuration modal, persisted key mappings, and an active-screen keyboard listener that can score or revert points from mapped remote buttons without using the Web Bluetooth API.
+- Identified dependencies:
+  - Existing input module: `src/lib/input/keyboard-aliases.ts`, `src/lib/input/use-input-handler.tsx`, `src/lib/input/wake-lock.tsx`
+  - Active match state and scoring: `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx`, `src/components/ActiveMatchScreen/useMatchSession.ts`, `src/lib/current-match/session.ts`, `src/core/match/types.ts`
+  - IndexedDB bootstrap and storage patterns: `src/lib/persistence/indexed-db.ts`, `src/lib/i18n/locale-storage.ts`, `src/lib/speech/speech-storage.ts`, `test/current-match/indexed-db.browser.test.ts`
+  - Setup UI and modal patterns: `src/components/SetupScreen/SetupScreen.tsx`, `src/components/SetupScreen/SetupScreen.module.css`, `src/components/ActiveMatchScreen/SideSwitchPrompt/SideSwitchPrompt.tsx`, `src/components/CurrentMatchStartupGate/CurrentMatchStartupGate.tsx`
+  - Copy and localization: `src/lib/i18n/locales/en.ts`, `src/lib/i18n/locales/es.ts`, `src/lib/i18n/locales/pt.ts`
+- System impact:
+  - Modify the shared IndexedDB bootstrap, which requires a database version bump so existing installs receive the new object store.
+  - Rework the input layer from hardcoded `score-team-*` / `undo` aliases into a resolver that supports persisted remote mappings plus legacy fallback aliases.
+  - Add new SetupScreen UI and new ActiveMatchScreen side effects, plus browser/unit tests across input, storage, and component layers.
+  - Preserve the current scoring domain and `undoScoreAction()` model unless product explicitly asks for a true history-editing “remove last point for team X” feature; the simplest safe interpretation for this issue is team-aware remote revert = guarded undo when the latest scoring action belongs to that team.
+
+## Chosen Approach
+
+- Proposed solution:
+  - Keep Bluetooth support at the keyboard-event layer and do not introduce a global provider, route change, or scoring-engine rewrite.
+  - Layer persisted remote bindings on top of the existing keyboard alias system: custom remote mappings handle `add-team-1`, `revert-team-1`, `add-team-2`, and `revert-team-2`, while the current built-in aliases continue to work as legacy defaults (`ArrowLeft`, `ArrowRight`, and the current undo keys).
+  - Reimplement `useInputHandler` as an ActiveMatchScreen-focused keyboard hook that consumes the live action list plus score/undo callbacks, buffers add presses for a single double-press window (~350–400 ms), converts a second same-team press into a guarded revert, and prevents default browser behavior for any resolved mapped key.
+  - Add a focused `RemoteConfigurationModal` in `SetupScreen` using the existing Base UI Dialog pattern and IndexedDB storage pattern already used by locale/speech preferences.
+- Justification for simplicity:
+  - Rejected approach 1: introducing app-wide remote/input context would add lifecycle complexity for a feature that is only needed on SetupScreen and ActiveMatchScreen.
+  - Rejected approach 2: adding new match-domain actions for `revert-team-1` / `revert-team-2` would force a scoring-engine and UI semantics change that is not required to satisfy the accepted remote-controller scope.
+  - Rejected approach 3: optimistic add-then-undo double-click handling is harder to reason about and risks score flashing; a single buffered add window is simpler and safer for score integrity.
+  - The selected path keeps the change set localized to input/storage/UI integration, reuses existing IndexedDB and Dialog patterns, and limits regression risk in `src/core/match/`.
+- Components to be modified/created:
+  - Modify: `src/lib/persistence/indexed-db.ts`
+  - Modify: `src/lib/input/keyboard-aliases.ts`, `src/lib/input/use-input-handler.tsx`, `src/lib/input/index.ts`
+  - Create: `src/lib/input/remote-controller-storage.ts`
+  - Modify: `src/components/SetupScreen/SetupScreen.tsx`, `src/components/SetupScreen/SetupScreen.module.css`
+  - Create: `src/components/SetupScreen/RemoteConfigurationModal.tsx`, `src/components/SetupScreen/RemoteConfigurationModal.module.css`
+  - Modify: `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx`
+  - Modify: `src/lib/i18n/locales/en.ts`, `src/lib/i18n/locales/es.ts`, `src/lib/i18n/locales/pt.ts`
+  - Modify/Create tests: `test/input/keyboard-aliases.test.ts`, `test/input/use-input-handler.browser.test.tsx`, `test/input/regression.test.ts`, `test/current-match/indexed-db.browser.test.ts`, `test/components/SetupScreen/SetupScreen.browser.test.tsx`, `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx`, `test/input/remote-controller-storage.test.ts`
+  - Plan document path: `/Users/trystan2k/Documents/Thiago/Repos/padelbuddy-web/docs/plan/Plan PBW-83 Bluetooth Remote Controller Support.md`
+
+## Implementation Steps
+
+1. Lock the behavior boundary before coding.
+   - Files/reference only: `docs/prd/bluetooth-remote-support.md`, `src/core/match/types.ts`, `src/lib/current-match/session.ts`, `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx`.
+   - Changes to make: document in the implementation notes and code comments that remote `revert-team-1` / `revert-team-2` are implemented as guarded undo against the latest scoring action for that same team, while the existing on-screen revert buttons remain unchanged.
+   - Why: the current domain only supports append-only score actions plus `undoScoreAction()`, so silently introducing true team-specific historical deletion would expand scope and risk scoring regressions.
+   - Risk/Mitigation: this is the highest-risk semantic assumption; if stakeholders reject guarded undo, stop and split a follow-up issue for scoring-engine changes before implementation continues.
+2. Extend IndexedDB bootstrap and add remote-controller persistence.
+   - Modify `src/lib/persistence/indexed-db.ts`:
+     - add a new shared object store constant for remote-controller preferences;
+     - bump `persistenceDatabaseVersion` so previously installed databases receive the new store during upgrade;
+     - include the new store in `sharedIndexedDbObjectStoreNames`.
+   - Create `src/lib/input/remote-controller-storage.ts` following `locale-storage.ts` / `speech-storage.ts`:
+     - define the stored shape for the four configurable remote bindings plus `updatedAt` metadata;
+     - expose `createRemoteControllerStorage`, `loadRemoteControllerBindings`, `saveRemoteControllerBindings`, and `clearRemoteControllerBindings`;
+     - validate stored data and fall back to `null` / defaults if the record is malformed.
+   - Add or update tests:
+     - create `test/input/remote-controller-storage.test.ts` mirroring the locale/speech storage suite;
+     - extend `test/current-match/indexed-db.browser.test.ts` to verify the new remote store can coexist in the shared database bootstrap with current match, locale, and speech persistence.
+   - Why: persistence must exist before either screen can load or save remote mappings.
+   - Risk/Mitigation: IndexedDB version bumps are sticky in real browsers, so browser tests must pass before merging; if the upgrade path breaks, revert the version bump within the branch before release rather than shipping a partially upgraded schema.
+3. Refactor keyboard mapping from hardcoded aliases into a layered resolver.
+   - Modify `src/lib/input/keyboard-aliases.ts`:
+     - expand the action model to support `add-team-1`, `revert-team-1`, `add-team-2`, `revert-team-2`, `undo`, and `unknown`;
+     - keep the current hardcoded alias set as a legacy fallback map so existing keyboard shortcuts continue to work by default;
+     - add key-normalization and lookup helpers that first check persisted remote bindings, then fall back to the legacy alias map;
+     - centralize any “display label” helper needed by the configuration modal so key names render consistently.
+   - Modify `src/lib/input/index.ts` to export the new types/helpers.
+   - Update `test/input/keyboard-aliases.test.ts` and the alias portions of `test/input/regression.test.ts` to cover:
+     - legacy default mappings still resolving correctly;
+     - custom persisted bindings overriding or augmenting legacy behavior;
+     - unknown keys and case normalization;
+     - duplicate/empty custom bindings resolving predictably.
+   - Why: the hook and the modal both need one authoritative source of truth for resolving and displaying key mappings.
+4. Reimplement `useInputHandler` around buffered remote actions instead of session-level debounce.
+   - Modify `src/lib/input/use-input-handler.tsx`:
+     - replace the current hard dependency on `CurrentMatchSession` with a simpler screen-integration API built around the current action list plus async callbacks such as `onAdd(teamId)` and `onUndo()`;
+     - keep the existing modifier-key and editable-target guards so browser shortcuts and text entry are not broken;
+     - resolve actions through the new layered keyboard mapping helper;
+     - prevent default browser behavior for any resolved mapping;
+     - remove the old global 300 ms scoring debounce from keyboard handling and replace it with a per-team buffered add window (~350–400 ms) that delays a score long enough to detect a double-press for the same team;
+     - when the second same-team add press lands inside the window, cancel the pending add and execute the guarded revert path instead;
+     - when an explicit `revert-team-*` mapping is pressed, call guarded undo immediately;
+     - keep timer cleanup and wake-lock cleanup safe on unmount, but do not expand wake-lock scope as part of this issue.
+   - Update `test/input/use-input-handler.browser.test.tsx` to cover:
+     - single mapped add press commits after the buffer window;
+     - double-press within the window reverts instead of scoring;
+     - explicit revert mapping only undoes when the latest action belongs to that team;
+     - legacy undo keys still work;
+     - `preventDefault()` is called for mapped keys;
+     - unmapped keys, modifier keys, and focused inputs remain ignored.
+   - Update `test/input/regression.test.ts` so remote input still produces the same canonical match state as direct session calls.
+   - Why: this is the core engine change required to make remote presses reliable on the active game screen.
+5. Add the SetupScreen “Remote Configuration” modal using the existing dialog pattern.
+   - Create `src/components/SetupScreen/RemoteConfigurationModal.tsx` and `RemoteConfigurationModal.module.css`.
+   - Build it with `@base-ui/react/dialog` following the patterns already used in `SideSwitchPrompt` and `CurrentMatchStartupGate`.
+   - Modal responsibilities:
+     - load the current stored bindings on open;
+     - render four rows for Add Team 1 / Revert Team 1 / Add Team 2 / Revert Team 2;
+     - enter a “listening” state when the user chooses to bind one action;
+     - capture the next physical key press via `window` keydown while the modal is open, preventing dialog-close side effects for keys like `Escape` when capture is active;
+     - enforce one key per configurable action by clearing/replacing duplicates rather than allowing ambiguous assignments;
+     - expose `Clear`, `Reset defaults`, `Cancel`, and `Save` actions;
+     - use the existing toast system for load/save failure feedback and non-blocking success feedback if the UX needs confirmation.
+   - Modify `src/components/SetupScreen/SetupScreen.tsx` and `SetupScreen.module.css` to add a clearly labeled trigger in the pre-match settings area, maintain modal open/close state, and keep the new UI aligned with existing SetupScreen layout and token usage.
+   - Why: configuration belongs before the match starts, and the app already has accessible modal patterns that fit this requirement.
+   - Risk/Mitigation: keyboard capture inside a dialog can conflict with dialog shortcuts; test `Escape`, arrow keys, Backspace, and Delete explicitly while the modal is in listening mode.
+6. Integrate remote input on the active match screen without changing touch behavior.
+   - Modify `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx`:
+     - load persisted remote bindings on mount and keep a local ready/default state;
+     - call the reworked `useInputHandler` with `snapshot.actions`, `scorePoint`, `undoScoreAction`, `enabled`, and the loaded mappings;
+     - keep the existing TeamPanel click handlers and on-screen revert buttons immediate so touch UX does not inherit the remote delay window;
+     - fall back to the legacy alias map if remote preferences fail to load.
+   - Do not widen the change into `useMatchSession.ts` unless the hook refactor reveals a genuine need; prefer to keep session management stable.
+   - Update `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx` to simulate keyboard events against the rendered screen and verify add, guarded revert, and `preventDefault()` behavior from the screen boundary rather than only at the hook level.
+   - Why: ActiveMatchScreen is the only runtime surface where mapped remote events should affect scoring.
+7. Add copy, localization, and regression coverage, then run the full QA gate.
+   - Modify `src/lib/i18n/locales/en.ts`, `es.ts`, and `pt.ts` with:
+     - the SetupScreen trigger label;
+     - modal title, description, action labels, listening state, clear/reset/save/cancel copy;
+     - any toast/error strings needed for persistence failures.
+   - Re-run and update any affected component snapshots/assertions in:
+     - `test/components/SetupScreen/SetupScreen.browser.test.tsx`
+     - `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx`
+     - `test/input/*`
+     - `test/current-match/indexed-db.browser.test.ts`
+   - Finish with targeted manual validation using a Bluetooth keyboard/HID remote plus `pnpm complete-check`.
+   - Why: the feature spans storage, i18n, modal UX, and active-screen input, so the final pass must validate both automated coverage and the real-device interaction path.
+
+## Validation
+
+- Success criteria:
+  - SetupScreen exposes a working “Remote Configuration” entry point and modal.
+  - Users can bind physical keys for Add Team 1, Revert Team 1, Add Team 2, and Revert Team 2, and those bindings persist across reloads through IndexedDB.
+  - ActiveMatchScreen responds to mapped keys only while active, prevents default browser behavior for mapped keys, and leaves form inputs/browser shortcuts alone when the screen should not handle them.
+  - A single mapped add press scores after the configured buffer window, while a second same-team press inside the window triggers the guarded revert path instead.
+  - Legacy default keyboard shortcuts (`ArrowLeft`, `ArrowRight`, current undo keys) still work when no custom remote mapping overrides them.
+  - No scoring-engine files in `src/core/match/` need to change for this issue.
+  - `pnpm complete-check` passes after the feature is implemented.
+- Checkpoints:
+  - Pre-implementation: confirm the guarded-undo interpretation for team-specific remote revert; if not accepted, stop and re-scope before coding.
+  - After Step 2: IndexedDB tests prove the new shared object store upgrades cleanly and remote bindings can be saved/loaded/cleared.
+  - After Step 3: alias resolver tests prove legacy defaults and custom overrides both resolve correctly.
+  - After Step 4: hook tests prove buffered add, double-press revert, `preventDefault()`, and editable-target guards all work deterministically.
+  - After Step 5: SetupScreen browser tests prove the modal opens, captures keys, saves bindings, and handles duplicate or cleared assignments correctly.
+  - After Step 6: ActiveMatchScreen browser tests prove the live screen reacts to mapped remote events without delaying touch interactions.
+  - Post-implementation: run manual Bluetooth keyboard/HID checks for single press, double press, explicit revert mapping, refresh persistence, and no-op guarded revert when the latest action belongs to the other team.
+  - Rollback trigger: if buffered remote input introduces scoring regressions or IndexedDB upgrade failures, revert the PBW-83 input/storage changes as a unit rather than partially shipping the modal without runtime support.

--- a/docs/prd/bluetooth-remote-support.md
+++ b/docs/prd/bluetooth-remote-support.md
@@ -1,0 +1,73 @@
+## Overview
+
+### Context
+
+During a padel match, players or referees often cannot easily interact with a phone/tablet screen due to sweat, distance, or convenience. Supporting inexpensive Bluetooth remote controllers (which pair at the OS level and act as Bluetooth keyboards/media buttons) allows users to seamlessly add or revert scores without touching the device. This greatly enhances the on-court user experience.
+
+### Task Description
+
+Implement a customizable global keyboard event listener on the active game screen to support Bluetooth remote controllers.
+
+The feature must include:
+
+1. **Key Mapping UI**: A configuration modal/drawer where users can assign physical button presses to four specific actions: Add Team A, Revert Team A, Add Team B, Revert Team B.
+2. **Action Engine**: A listener that triggers the score updates based on the mapped keys.
+3. **Software Double-Click Detection**: To support simple 2-button controllers, the app must detect double-clicks on the "Add" buttons. If a user double-clicks the button mapped to "Add Team A" within a ~400ms window, it should execute "Revert Team A" instead.
+4. **Local Persistence**: Save the configured key mappings in local storage so the user doesn't have to remap their controller every time they open the app.
+
+## Planning
+
+### Depends On
+
+- None (Assumes the active game screen and scoring engine are already implemented)
+
+### Risk
+
+**Level**: Medium
+
+**Explanation**:
+Handling global keyboard events on mobile web browsers can be tricky, especially with media keys (like Volume Up/Down). Some OS-level events cannot be perfectly overridden (e.g., volume might still change on the phone). Additionally, handling the double-click logic requires careful timing so the UI doesn't feel laggy or cause score "flashing" (adding a point and immediately removing two).
+
+## Requirements
+
+### Acceptance Criteria
+
+- [ ] A "Remote Configuration" UI is accessible from the active game screen (or match settings).
+- [ ] The user can focus an input/action and press a physical button on their remote to bind it to: Add Team A, Revert Team A, Add Team B, Revert Team B.
+- [ ] The key mappings are persisted across app reloads via LocalStorage or similar persistent store.
+- [ ] On the active game screen, pressing a mapped key triggers the correct scoring action.
+- [ ] If the user double-clicks (two presses within ~400ms) a key mapped to "Add", it triggers the "Revert" action for that team instead.
+  - _UX Note_: The implementation should either slightly delay the "Add" action by ~300ms to wait for a potential second click, OR optimistically add the point and if a second click is detected, quickly undo it and apply the revert. (Delay is usually safer for score integrity).
+- [ ] Default browser behaviors (like page scrolling for Spacebar/Arrows) are prevented (`e.preventDefault()`) when the key is mapped and the game screen is active.
+
+## Quality Assurance
+
+### Test Plan
+
+**Automated Tests**:
+
+- Unit tests for the double-click detection hook/utility (verifying timing and correct action dispatch).
+- Unit tests for the mapping configuration logic (saving/loading from storage).
+- E2E/Integration tests simulating keyboard events on the active game screen to ensure points are added/reverted.
+
+- **Manual Testing**:
+
+1. Pair a standard Bluetooth keyboard (or media remote) to the testing device.
+2. Navigate to the game screen and open the remote configuration.
+3. Map "Arrow Left" to Team A Add, "Arrow Right" to Team B Add.
+4. Go back to the game. Press Left Arrow -> Verify Team A score increases.
+5. Double-click Left Arrow -> Verify Team A score decreases (reverts).
+6. Map unique keys to the Revert actions and verify they work on single clicks (simulating a 4-button controller).
+7. Refresh the page and ensure the mapped keys are still active.
+
+**Edge Cases**:
+
+- Rapid, spammy button presses (e.g., clicking 5 times fast).
+- Pressing a button that is mapped to an action, but the action is currently invalid (e.g., trying to revert a score when it's already at 0-0).
+- Device goes to sleep and wakes up (re-pairing Bluetooth usually sends a flurry of connection events, ensure no phantom points are added).
+
+### Definition of Done
+
+- [ ] All subtasks delivered
+- [ ] QA Control Gate passed
+- [ ] User review approved

--- a/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
+++ b/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
@@ -6,7 +6,7 @@ import { Layout } from '@/components/Layout/Layout'
 import { TopBar } from '@/components/ui/TopBar'
 import {
   createEmptyRemoteControllerBindings,
-  loadRemoteControllerBindings,
+  loadRemoteControllerBindingsWithFallback,
   useInputHandler,
   type RemoteControllerBindings
 } from '@/lib/input'
@@ -88,13 +88,13 @@ export function ActiveMatchScreen({
 
     void (async () => {
       try {
-        const storedBindings = await loadRemoteControllerBindings()
+        const storedBindings = await loadRemoteControllerBindingsWithFallback()
 
         if (!isMounted) {
           return
         }
 
-        setRemoteBindings(storedBindings ?? createEmptyRemoteControllerBindings())
+        setRemoteBindings(storedBindings)
       } catch (error) {
         console.error('Failed to load remote controller bindings.', error)
 

--- a/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
+++ b/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
@@ -4,6 +4,12 @@ import { useTranslation } from 'react-i18next'
 
 import { Layout } from '@/components/Layout/Layout'
 import { TopBar } from '@/components/ui/TopBar'
+import {
+  createEmptyRemoteControllerBindings,
+  loadRemoteControllerBindings,
+  useInputHandler,
+  type RemoteControllerBindings
+} from '@/lib/input'
 import { prepareCurrentMatchRouteNavigation } from '@/lib/router/current-match-route-flow'
 import { cn } from '@/lib/utils/cn'
 import { getViewTransitionNavigationOptions } from '@/lib/utils/view-transitions'
@@ -38,14 +44,18 @@ export function ActiveMatchScreen({
   const { t } = useTranslation()
   const [sideSwitchDismissed, setSideSwitchDismissed] = useState(false)
   const [isNavigatingToFinish, setIsNavigatingToFinish] = useState(false)
+  const [remoteBindings, setRemoteBindings] = useState<RemoteControllerBindings>(
+    createEmptyRemoteControllerBindings()
+  )
 
-  const { snapshot, scorePoint, undoScoreAction, finishMatch, isLoading } = useMatchSession({
-    matchId,
-    setup: initialSetup,
-    initialActions,
-    startedAt,
-    ...(typeof finishedAt === 'number' ? { initialFinishedAt: finishedAt } : {})
-  })
+  const { snapshot, scorePoint, undoScoreAction, undoScoreActionForTeam, finishMatch, isLoading } =
+    useMatchSession({
+      matchId,
+      setup: initialSetup,
+      initialActions,
+      startedAt,
+      ...(typeof finishedAt === 'number' ? { initialFinishedAt: finishedAt } : {})
+    })
 
   const isMatchCompleted =
     snapshot.projection.derived.status === 'completed' || typeof snapshot.finishedAt === 'number'
@@ -72,6 +82,34 @@ export function ActiveMatchScreen({
       setSideSwitchDismissed(false)
     }
   }, [sideSwitch.shouldPrompt])
+
+  useEffect(() => {
+    let isMounted = true
+
+    void (async () => {
+      try {
+        const storedBindings = await loadRemoteControllerBindings()
+
+        if (!isMounted) {
+          return
+        }
+
+        setRemoteBindings(storedBindings ?? createEmptyRemoteControllerBindings())
+      } catch (error) {
+        console.error('Failed to load remote controller bindings.', error)
+
+        if (!isMounted) {
+          return
+        }
+
+        setRemoteBindings(createEmptyRemoteControllerBindings())
+      }
+    })()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
 
   useEffect(() => {
     if (!isMatchCompleted || isNavigatingToFinish) {
@@ -137,6 +175,57 @@ export function ActiveMatchScreen({
     await undoScoreAction()
   }, [isLoading, undoScoreAction])
 
+  const handleRevertTeam1 = useCallback(async () => {
+    if (isLoading) {
+      return
+    }
+
+    await undoScoreActionForTeam('team-1')
+  }, [isLoading, undoScoreActionForTeam])
+
+  const handleRevertTeam2 = useCallback(async () => {
+    if (isLoading) {
+      return
+    }
+
+    await undoScoreActionForTeam('team-2')
+  }, [isLoading, undoScoreActionForTeam])
+
+  const handleRemoteAdd = useCallback(
+    async (teamId: MatchTeamId) => {
+      if (isLoading || isMatchCompleted) {
+        return
+      }
+
+      await scorePoint(teamId)
+    },
+    [isLoading, isMatchCompleted, scorePoint]
+  )
+
+  const handleRemoteUndoForTeam = useCallback(
+    async (teamId: MatchTeamId) => {
+      if (isLoading || isMatchCompleted) {
+        return
+      }
+
+      await undoScoreActionForTeam(teamId)
+    },
+    [isLoading, isMatchCompleted, undoScoreActionForTeam]
+  )
+
+  useInputHandler(
+    {
+      actions: snapshot.actions,
+      bindings: remoteBindings,
+      enabled: !isMatchCompleted
+    },
+    {
+      onAdd: handleRemoteAdd,
+      onUndo: handleRevert,
+      onUndoForTeam: handleRemoteUndoForTeam
+    }
+  )
+
   const handleFinish = useCallback(async () => {
     if (isLoading || isMatchCompleted) {
       return
@@ -152,7 +241,10 @@ export function ActiveMatchScreen({
   const shouldShowSideSwitch =
     sideSwitch.shouldPrompt && setup.sideSwitchPrompts && !sideSwitchDismissed
   const timerLabelKey = countdownEnabled ? 'match.timer.countdownLabel' : 'match.timer.label'
-  const isUndoDisabled = isLoading || snapshot.actions.length === 0
+  const canUndoTeam1 = snapshot.actions.some((action) => action.teamId === 'team-1')
+  const canUndoTeam2 = snapshot.actions.some((action) => action.teamId === 'team-2')
+  const isUndoTeam1Disabled = isLoading || !canUndoTeam1
+  const isUndoTeam2Disabled = isLoading || !canUndoTeam2
 
   const headerContent = useMemo(
     () => (
@@ -206,8 +298,8 @@ export function ActiveMatchScreen({
           <button
             type="button"
             className={cn(styles.revertButton, styles.revertButtonTeam1)}
-            onClick={handleRevert}
-            disabled={isUndoDisabled}
+            onClick={handleRevertTeam1}
+            disabled={isUndoTeam1Disabled}
             data-testid="revert-button-team-1"
           >
             {t('match.actions.revertPoint')}
@@ -227,8 +319,8 @@ export function ActiveMatchScreen({
           <button
             type="button"
             className={cn(styles.revertButton, styles.revertButtonTeam2)}
-            onClick={handleRevert}
-            disabled={isUndoDisabled}
+            onClick={handleRevertTeam2}
+            disabled={isUndoTeam2Disabled}
             data-testid="revert-button-team-2"
           >
             {t('match.actions.revertPoint')}

--- a/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
+++ b/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
@@ -241,8 +241,20 @@ export function ActiveMatchScreen({
   const shouldShowSideSwitch =
     sideSwitch.shouldPrompt && setup.sideSwitchPrompts && !sideSwitchDismissed
   const timerLabelKey = countdownEnabled ? 'match.timer.countdownLabel' : 'match.timer.label'
-  const canUndoTeam1 = snapshot.actions.some((action) => action.teamId === 'team-1')
-  const canUndoTeam2 = snapshot.actions.some((action) => action.teamId === 'team-2')
+  const canUndoTeam1 = useMemo(
+    () =>
+      snapshot.actions.some(
+        (action) => action.type === 'score-point' && action.teamId === 'team-1'
+      ),
+    [snapshot.actions]
+  )
+  const canUndoTeam2 = useMemo(
+    () =>
+      snapshot.actions.some(
+        (action) => action.type === 'score-point' && action.teamId === 'team-2'
+      ),
+    [snapshot.actions]
+  )
   const isUndoTeam1Disabled = isLoading || !canUndoTeam1
   const isUndoTeam2Disabled = isLoading || !canUndoTeam2
 

--- a/src/components/ActiveMatchScreen/useMatchSession.ts
+++ b/src/components/ActiveMatchScreen/useMatchSession.ts
@@ -20,6 +20,7 @@ export interface UseMatchSessionReturn {
   snapshot: CurrentMatchSessionSnapshot
   scorePoint: (teamId: MatchTeamId) => Promise<void>
   undoScoreAction: () => Promise<void>
+  undoScoreActionForTeam: (teamId: MatchTeamId) => Promise<void>
   finishMatch: () => Promise<void>
   isLoading: boolean
 }
@@ -71,6 +72,19 @@ export function useMatchSession(options: UseMatchSessionOptions): UseMatchSessio
     }
   }, [session])
 
+  const undoScoreActionForTeam = useCallback(
+    async (teamId: MatchTeamId) => {
+      setIsLoading(true)
+      try {
+        const newSnapshot = await session.undoScoreActionForTeam(teamId)
+        setSnapshot(newSnapshot)
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [session]
+  )
+
   const finishMatch = useCallback(async () => {
     setIsLoading(true)
     try {
@@ -85,6 +99,7 @@ export function useMatchSession(options: UseMatchSessionOptions): UseMatchSessio
     snapshot,
     scorePoint,
     undoScoreAction,
+    undoScoreActionForTeam,
     finishMatch,
     isLoading
   }

--- a/src/components/SetupScreen/RemoteConfigurationModal.module.css
+++ b/src/components/SetupScreen/RemoteConfigurationModal.module.css
@@ -1,0 +1,154 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--overlay-z-index);
+  background: var(--overlay-background);
+}
+
+.container {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: var(--base-priority-xxl);
+  width: min(calc(100vw - var(--base-space-32)), 36rem);
+  max-height: min(80vh, 42rem);
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  gap: var(--base-space-20);
+  padding: var(--base-space-24);
+  overflow: auto;
+  background-color: var(--semantic-color-background-surface);
+  border-radius: var(--base-radius-24);
+  box-shadow: 0 12px 36px rgb(0 0 0 / 18%);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--base-space-8);
+}
+
+.title {
+  margin: 0;
+  font-family: var(--semantic-typography-family-display);
+  font-size: var(--semantic-typography-size-title-md);
+  font-weight: var(--semantic-typography-weight-strong);
+  color: var(--semantic-color-content-primary);
+}
+
+.description {
+  margin: 0;
+  font-family: var(--semantic-typography-family-body);
+  font-size: var(--semantic-typography-size-body-md);
+  color: var(--semantic-color-content-secondary);
+}
+
+.rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--base-space-12);
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--base-space-16);
+  padding: var(--base-space-16);
+  border: 1px solid var(--semantic-color-border-subtle);
+  border-radius: var(--base-radius-20);
+  background-color: var(--semantic-color-background-surface-muted);
+}
+
+.rowText {
+  display: flex;
+  flex-direction: column;
+  gap: var(--base-space-4);
+  min-width: 0;
+}
+
+.rowLabel {
+  font-family: var(--semantic-typography-family-display);
+  font-size: var(--semantic-typography-size-title-sm);
+  font-weight: var(--semantic-typography-weight-strong);
+  color: var(--semantic-color-content-primary);
+}
+
+.rowHint {
+  font-family: var(--semantic-typography-family-body);
+  font-size: var(--base-font-size-14);
+  color: var(--semantic-color-content-secondary);
+}
+
+.captureButton {
+  min-width: 8rem;
+}
+
+.captureValue {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 4.5rem;
+}
+
+.captureValueEmpty {
+  color: var(--semantic-color-content-secondary);
+}
+
+.captureValueListening {
+  color: var(--semantic-color-content-accent-primary);
+}
+
+.helperText {
+  margin: 0;
+  font-family: var(--semantic-typography-family-body);
+  font-size: var(--base-font-size-14);
+  color: var(--semantic-color-content-secondary);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--base-space-12);
+}
+
+.footerGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--base-space-12);
+}
+
+@media (width < 30rem) {
+  .row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .captureButton {
+    width: 100%;
+  }
+
+  .footer,
+  .footerGroup {
+    flex-direction: column;
+  }
+
+  .footer > *,
+  .footerGroup > * {
+    width: 100%;
+  }
+}

--- a/src/components/SetupScreen/RemoteConfigurationModal.tsx
+++ b/src/components/SetupScreen/RemoteConfigurationModal.tsx
@@ -1,6 +1,6 @@
 /* oxlint-disable jsx-no-new-function-as-prop -- Base UI Dialog uses render props for accessible composition. */
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Dialog } from '@base-ui/react/dialog'
 import { useTranslation } from 'react-i18next'
 
@@ -12,9 +12,8 @@ import {
   configurableKeyboardActions,
   createEmptyRemoteControllerBindings,
   createRemoteControllerBindings,
-  defaultRemoteControllerBindings,
   getKeyboardBindingDisplayLabel,
-  loadRemoteControllerBindings,
+  loadRemoteControllerBindingsWithFallback,
   saveRemoteControllerBindings,
   type ConfigurableKeyboardAction,
   type RemoteControllerBindings
@@ -42,6 +41,13 @@ export function RemoteConfigurationModal({ isOpen, onClose }: RemoteConfiguratio
   )
   const [listeningAction, setListeningAction] = useState<ConfigurableKeyboardAction | null>(null)
   const [isSaving, setIsSaving] = useState(false)
+  const closeGuardRef = useRef(false)
+
+  useEffect(() => {
+    if (isOpen) {
+      closeGuardRef.current = false
+    }
+  }, [isOpen])
 
   useEffect(() => {
     if (!isOpen) {
@@ -53,13 +59,13 @@ export function RemoteConfigurationModal({ isOpen, onClose }: RemoteConfiguratio
 
     void (async () => {
       try {
-        const storedBindings = await loadRemoteControllerBindings()
+        const storedBindings = await loadRemoteControllerBindingsWithFallback()
 
         if (!isMounted) {
           return
         }
 
-        setDraftBindings(storedBindings ?? createEmptyRemoteControllerBindings())
+        setDraftBindings(storedBindings)
       } catch (error) {
         console.error('Failed to load remote controller bindings.', error)
 
@@ -103,6 +109,24 @@ export function RemoteConfigurationModal({ isOpen, onClose }: RemoteConfiguratio
     }
   }, [isOpen, listeningAction])
 
+  const requestClose = useCallback(() => {
+    if (closeGuardRef.current) {
+      return
+    }
+
+    closeGuardRef.current = true
+    onClose()
+  }, [onClose])
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        requestClose()
+      }
+    },
+    [requestClose]
+  )
+
   const handleSave = useCallback(async () => {
     setIsSaving(true)
 
@@ -116,7 +140,7 @@ export function RemoteConfigurationModal({ isOpen, onClose }: RemoteConfiguratio
       }
 
       addSuccessToast(t('setup.remoteConfig.feedback.saveSuccess'))
-      onClose()
+      requestClose()
     } catch (error) {
       const saveError = toError(error)
       addErrorToast(`${t('setup.remoteConfig.feedback.saveError')} ${saveError.message}`)
@@ -124,7 +148,7 @@ export function RemoteConfigurationModal({ isOpen, onClose }: RemoteConfiguratio
       setIsSaving(false)
       setListeningAction(null)
     }
-  }, [addErrorToast, addSuccessToast, draftBindings, onClose, t])
+  }, [addErrorToast, addSuccessToast, draftBindings, requestClose, t])
 
   const handleClear = useCallback(() => {
     setListeningAction(null)
@@ -133,7 +157,7 @@ export function RemoteConfigurationModal({ isOpen, onClose }: RemoteConfiguratio
 
   const handleResetDefaults = useCallback(() => {
     setListeningAction(null)
-    setDraftBindings(createRemoteControllerBindings(defaultRemoteControllerBindings))
+    setDraftBindings(createRemoteControllerBindings())
   }, [])
 
   const bindingRows = useMemo(
@@ -174,7 +198,7 @@ export function RemoteConfigurationModal({ isOpen, onClose }: RemoteConfiguratio
     : ''
 
   return (
-    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
+    <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
       <Dialog.Portal>
         <Dialog.Backdrop render={(props) => <div {...props} className={styles.overlay} />} />
 
@@ -265,7 +289,7 @@ export function RemoteConfigurationModal({ isOpen, onClose }: RemoteConfiguratio
                 </div>
 
                 <div className={styles.footerGroup}>
-                  <Button variant="outline" size="sm" accent="secondary" onClick={onClose}>
+                  <Button variant="outline" size="sm" accent="secondary" onClick={requestClose}>
                     {t('setup.remoteConfig.actions.cancel')}
                   </Button>
                   <Button

--- a/src/components/SetupScreen/RemoteConfigurationModal.tsx
+++ b/src/components/SetupScreen/RemoteConfigurationModal.tsx
@@ -1,0 +1,288 @@
+/* oxlint-disable jsx-no-new-function-as-prop -- Base UI Dialog uses render props for accessible composition. */
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Dialog } from '@base-ui/react/dialog'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/Button'
+import { useToast } from '@/components/ui/Toast'
+import {
+  assignRemoteControllerBinding,
+  clearRemoteControllerBindings,
+  configurableKeyboardActions,
+  createEmptyRemoteControllerBindings,
+  createRemoteControllerBindings,
+  defaultRemoteControllerBindings,
+  getKeyboardBindingDisplayLabel,
+  loadRemoteControllerBindings,
+  saveRemoteControllerBindings,
+  type ConfigurableKeyboardAction,
+  type RemoteControllerBindings
+} from '@/lib/input'
+import { cn } from '@/lib/utils/cn'
+
+import styles from './RemoteConfigurationModal.module.css'
+
+const ignoredCaptureKeys = new Set(['Alt', 'Control', 'Meta', 'Shift'])
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+export interface RemoteConfigurationModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function RemoteConfigurationModal({ isOpen, onClose }: RemoteConfigurationModalProps) {
+  const { t } = useTranslation()
+  const { addErrorToast, addSuccessToast } = useToast()
+  const [draftBindings, setDraftBindings] = useState<RemoteControllerBindings>(
+    createEmptyRemoteControllerBindings()
+  )
+  const [listeningAction, setListeningAction] = useState<ConfigurableKeyboardAction | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+
+  useEffect(() => {
+    if (!isOpen) {
+      setListeningAction(null)
+      return
+    }
+
+    let isMounted = true
+
+    void (async () => {
+      try {
+        const storedBindings = await loadRemoteControllerBindings()
+
+        if (!isMounted) {
+          return
+        }
+
+        setDraftBindings(storedBindings ?? createEmptyRemoteControllerBindings())
+      } catch (error) {
+        console.error('Failed to load remote controller bindings.', error)
+
+        if (!isMounted) {
+          return
+        }
+
+        setDraftBindings(createEmptyRemoteControllerBindings())
+        addErrorToast(t('setup.remoteConfig.feedback.loadError'))
+      }
+    })()
+
+    return () => {
+      isMounted = false
+    }
+  }, [addErrorToast, isOpen, t])
+
+  useEffect(() => {
+    if (!isOpen || !listeningAction) {
+      return
+    }
+
+    const handleCapture = (event: KeyboardEvent) => {
+      if (ignoredCaptureKeys.has(event.key)) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+
+      setDraftBindings((currentBindings) =>
+        assignRemoteControllerBinding(currentBindings, listeningAction, event.key)
+      )
+      setListeningAction(null)
+    }
+
+    window.addEventListener('keydown', handleCapture, true)
+
+    return () => {
+      window.removeEventListener('keydown', handleCapture, true)
+    }
+  }, [isOpen, listeningAction])
+
+  const handleSave = useCallback(async () => {
+    setIsSaving(true)
+
+    try {
+      const isCleared = configurableKeyboardActions.every((action) => !draftBindings[action])
+
+      if (isCleared) {
+        await clearRemoteControllerBindings()
+      } else {
+        await saveRemoteControllerBindings(draftBindings)
+      }
+
+      addSuccessToast(t('setup.remoteConfig.feedback.saveSuccess'))
+      onClose()
+    } catch (error) {
+      const saveError = toError(error)
+      addErrorToast(`${t('setup.remoteConfig.feedback.saveError')} ${saveError.message}`)
+    } finally {
+      setIsSaving(false)
+      setListeningAction(null)
+    }
+  }, [addErrorToast, addSuccessToast, draftBindings, onClose, t])
+
+  const handleClear = useCallback(() => {
+    setListeningAction(null)
+    setDraftBindings(createEmptyRemoteControllerBindings())
+  }, [])
+
+  const handleResetDefaults = useCallback(() => {
+    setListeningAction(null)
+    setDraftBindings(createRemoteControllerBindings(defaultRemoteControllerBindings))
+  }, [])
+
+  const bindingRows = useMemo(
+    () =>
+      [
+        {
+          action: 'add-team-1',
+          label: t('setup.remoteConfig.actions.addTeam1'),
+          hint: t('setup.remoteConfig.rows.singlePressHint')
+        },
+        {
+          action: 'revert-team-1',
+          label: t('setup.remoteConfig.actions.revertTeam1'),
+          hint: t('setup.remoteConfig.rows.guardedUndoHint')
+        },
+        {
+          action: 'add-team-2',
+          label: t('setup.remoteConfig.actions.addTeam2'),
+          hint: t('setup.remoteConfig.rows.singlePressHint')
+        },
+        {
+          action: 'revert-team-2',
+          label: t('setup.remoteConfig.actions.revertTeam2'),
+          hint: t('setup.remoteConfig.rows.guardedUndoHint')
+        }
+      ] satisfies Array<{
+        action: ConfigurableKeyboardAction
+        label: string
+        hint: string
+      }>,
+    [t]
+  )
+
+  const listeningAnnouncement = listeningAction
+    ? t('setup.remoteConfig.listeningAnnouncement', {
+        action: bindingRows.find((row) => row.action === listeningAction)?.label ?? ''
+      })
+    : ''
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Backdrop render={(props) => <div {...props} className={styles.overlay} />} />
+
+        <Dialog.Popup
+          render={(props) => (
+            <div
+              {...props}
+              className={styles.container}
+              aria-modal="true"
+              data-testid="remote-configuration-modal"
+            >
+              <div className={styles.header}>
+                <Dialog.Title
+                  render={(titleProps) => (
+                    <h2 {...titleProps} className={styles.title}>
+                      {t('setup.remoteConfig.title')}
+                    </h2>
+                  )}
+                />
+                <Dialog.Description
+                  render={(descriptionProps) => (
+                    <p {...descriptionProps} className={styles.description}>
+                      {t('setup.remoteConfig.description')}
+                    </p>
+                  )}
+                />
+              </div>
+
+              <span role="status" aria-live="polite" className={styles.srOnly}>
+                {listeningAnnouncement}
+              </span>
+
+              <div className={styles.rows}>
+                {bindingRows.map((row) => {
+                  const binding = draftBindings[row.action]
+                  const isListening = listeningAction === row.action
+
+                  return (
+                    <div key={row.action} className={styles.row}>
+                      <div className={styles.rowText}>
+                        <span className={styles.rowLabel}>{row.label}</span>
+                        <span className={styles.rowHint}>{row.hint}</span>
+                      </div>
+
+                      <Button
+                        className={styles.captureButton}
+                        variant={isListening ? 'solid' : 'outline'}
+                        size="sm"
+                        accent={isListening ? 'primary' : 'secondary'}
+                        onClick={() => setListeningAction(row.action)}
+                        aria-pressed={isListening}
+                        data-testid={`remote-binding-${row.action}`}
+                      >
+                        <span
+                          className={cn(
+                            styles.captureValue,
+                            isListening && styles.captureValueListening,
+                            !binding && !isListening && styles.captureValueEmpty
+                          )}
+                        >
+                          {isListening
+                            ? t('setup.remoteConfig.listening')
+                            : binding
+                              ? getKeyboardBindingDisplayLabel(binding)
+                              : t('setup.remoteConfig.notSet')}
+                        </span>
+                      </Button>
+                    </div>
+                  )
+                })}
+              </div>
+
+              <p className={styles.helperText}>{t('setup.remoteConfig.helper')}</p>
+
+              <div className={styles.footer}>
+                <div className={styles.footerGroup}>
+                  <Button variant="outline" size="sm" accent="secondary" onClick={handleClear}>
+                    {t('setup.remoteConfig.actions.clear')}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    accent="secondary"
+                    onClick={handleResetDefaults}
+                  >
+                    {t('setup.remoteConfig.actions.resetDefaults')}
+                  </Button>
+                </div>
+
+                <div className={styles.footerGroup}>
+                  <Button variant="outline" size="sm" accent="secondary" onClick={onClose}>
+                    {t('setup.remoteConfig.actions.cancel')}
+                  </Button>
+                  <Button
+                    variant="solid"
+                    size="sm"
+                    accent="success"
+                    onClick={handleSave}
+                    disabled={isSaving}
+                  >
+                    {t('setup.remoteConfig.actions.save')}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+        />
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/src/components/SetupScreen/SetupScreen.module.css
+++ b/src/components/SetupScreen/SetupScreen.module.css
@@ -197,6 +197,7 @@
   color: var(--semantic-color-content-secondary);
 }
 
+.remoteConfigurationButton,
 .startButton {
   width: 100%;
 }

--- a/src/components/SetupScreen/SetupScreen.tsx
+++ b/src/components/SetupScreen/SetupScreen.tsx
@@ -26,6 +26,7 @@ import { Toggle } from '@/components/ui/Toggle'
 import { TopBar } from '@/components/ui/TopBar'
 import { LocaleSelector } from '@/components/ui/LocaleSelector'
 
+import { RemoteConfigurationModal } from './RemoteConfigurationModal'
 import { useSetupForm } from './useSetupForm'
 import styles from './SetupScreen.module.css'
 
@@ -54,6 +55,7 @@ export function SetupScreen() {
   const navigate = useNavigate()
   const router = useRouter()
   const [isStarting, setIsStarting] = useState(false)
+  const [isRemoteConfigurationOpen, setIsRemoteConfigurationOpen] = useState(false)
 
   const {
     formData,
@@ -170,6 +172,14 @@ export function SetupScreen() {
     },
     [updateCountdownTimerDuration]
   )
+
+  const handleOpenRemoteConfiguration = useCallback(() => {
+    setIsRemoteConfigurationOpen(true)
+  }, [])
+
+  const handleCloseRemoteConfiguration = useCallback(() => {
+    setIsRemoteConfigurationOpen(false)
+  }, [])
 
   const handleCountdownDurationKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {
@@ -326,6 +336,16 @@ export function SetupScreen() {
               </Chip>
             </div>
           </div>
+
+          <Button
+            className={styles.remoteConfigurationButton}
+            variant="outline"
+            size="lg"
+            accent="secondary"
+            onClick={handleOpenRemoteConfiguration}
+          >
+            {t('setup.remoteConfig.trigger')}
+          </Button>
         </div>
 
         {/* Right column - Options */}
@@ -461,6 +481,11 @@ export function SetupScreen() {
           </Card>
         </div>
       </div>
+
+      <RemoteConfigurationModal
+        isOpen={isRemoteConfigurationOpen}
+        onClose={handleCloseRemoteConfiguration}
+      />
     </Layout>
   )
 }

--- a/src/lib/current-match/helpers.ts
+++ b/src/lib/current-match/helpers.ts
@@ -1,0 +1,16 @@
+import type { MatchAction, MatchTeamId } from '@/core/match'
+
+export function undoLastScoringActionForTeam(
+  actions: MatchAction[],
+  teamId: MatchTeamId
+): MatchAction[] {
+  const actionIndex = actions.findLastIndex(
+    (action) => action.type === 'score-point' && action.teamId === teamId
+  )
+
+  if (actionIndex < 0) {
+    return actions
+  }
+
+  return [...actions.slice(0, actionIndex), ...actions.slice(actionIndex + 1)]
+}

--- a/src/lib/current-match/index.ts
+++ b/src/lib/current-match/index.ts
@@ -35,6 +35,7 @@ export {
   type CurrentMatchSessionInput,
   type CurrentMatchSessionSnapshot
 } from './session'
+export { undoLastScoringActionForTeam } from './helpers'
 export {
   hydrateCurrentMatchStartup,
   type CurrentMatchStartupCorruptResult,

--- a/src/lib/current-match/session.ts
+++ b/src/lib/current-match/session.ts
@@ -9,6 +9,7 @@ import {
 } from '@/core/match'
 
 import { currentMatchPersistence, type CurrentMatchPersistence } from './indexed-db'
+import { undoLastScoringActionForTeam } from './helpers'
 
 export interface CurrentMatchSessionInput {
   setup: MatchSetup
@@ -29,6 +30,7 @@ export interface CurrentMatchSession {
   getSnapshot(): CurrentMatchSessionSnapshot
   scorePoint(teamId: MatchTeamId): Promise<CurrentMatchSessionSnapshot>
   undoScoreAction(): Promise<CurrentMatchSessionSnapshot>
+  undoScoreActionForTeam(teamId: MatchTeamId): Promise<CurrentMatchSessionSnapshot>
   continuePlaying(): Promise<CurrentMatchSessionSnapshot>
   finishMatch(): Promise<CurrentMatchSessionSnapshot>
 }
@@ -81,6 +83,25 @@ export function createCurrentMatchSession(
     undoScoreAction: () =>
       enqueueMutation(async () => {
         const nextActions = undoLastScoringAction(snapshot.actions)
+
+        if (nextActions.length === snapshot.actions.length) {
+          return snapshot
+        }
+
+        return commitSnapshot(
+          withFinishedAtIfCompleted(
+            createCurrentMatchSessionSnapshot({
+              setup: snapshot.setup,
+              actions: nextActions,
+              startedAt: snapshot.startedAt
+            }),
+            snapshot.finishedAt
+          )
+        )
+      }),
+    undoScoreActionForTeam: (teamId) =>
+      enqueueMutation(async () => {
+        const nextActions = undoLastScoringActionForTeam(snapshot.actions, teamId)
 
         if (nextActions.length === snapshot.actions.length) {
           return snapshot

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -182,6 +182,36 @@ export default {
         twoHours: '2:00 h'
       }
     },
+    remoteConfig: {
+      trigger: 'Remote Configuration',
+      title: 'Bluetooth Remote Controller',
+      description:
+        'Assign one button per action. Revert buttons always remove the latest scoring action for that team only.',
+      helper:
+        'While listening, press any remote or keyboard button once. Saving with every action cleared removes the custom mapping.',
+      listening: 'Listening...',
+      listeningAnnouncement: 'Press a button on your remote to assign it to {{action}}.',
+      notSet: 'Not set',
+      rows: {
+        singlePressHint: 'Single press to add a point',
+        guardedUndoHint: "Removes that team's latest scoring action"
+      },
+      actions: {
+        addTeam1: 'Add Team 1',
+        revertTeam1: 'Revert Team 1',
+        addTeam2: 'Add Team 2',
+        revertTeam2: 'Revert Team 2',
+        clear: 'Empty bindings',
+        resetDefaults: 'Reset defaults',
+        cancel: 'Cancel',
+        save: 'Save'
+      },
+      feedback: {
+        loadError: 'Could not load the remote controller bindings.',
+        saveError: 'Could not save the remote controller bindings.',
+        saveSuccess: 'Remote controller bindings saved.'
+      }
+    },
     startButton: 'Start Match',
     validation: {
       teamNamesRequired: 'Both team names are required',

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -183,6 +183,36 @@ export default {
         twoHours: '2:00 h'
       }
     },
+    remoteConfig: {
+      trigger: 'Configuración del control remoto',
+      title: 'Control remoto Bluetooth',
+      description:
+        'Asigna un botón por acción. Los botones de revertir siempre eliminan solo la última acción de puntuación de ese equipo.',
+      helper:
+        'Mientras está escuchando, presiona una vez cualquier botón del control o teclado. Guardar con todas las acciones vacías elimina la configuración personalizada.',
+      listening: 'Escuchando...',
+      listeningAnnouncement: 'Presiona un botón en tu control para asignarlo a {{action}}.',
+      notSet: 'Sin asignar',
+      rows: {
+        singlePressHint: 'Una pulsación para sumar un punto',
+        guardedUndoHint: 'Elimina la última acción de puntuación de ese equipo'
+      },
+      actions: {
+        addTeam1: 'Sumar Equipo 1',
+        revertTeam1: 'Revertir Equipo 1',
+        addTeam2: 'Sumar Equipo 2',
+        revertTeam2: 'Revertir Equipo 2',
+        clear: 'Asignaciones vacías',
+        resetDefaults: 'Restablecer predeterminados',
+        cancel: 'Cancelar',
+        save: 'Guardar'
+      },
+      feedback: {
+        loadError: 'No se pudo cargar la configuración del control remoto.',
+        saveError: 'No se pudo guardar la configuración del control remoto.',
+        saveSuccess: 'Configuración del control remoto guardada.'
+      }
+    },
     startButton: 'Iniciar Partido',
     validation: {
       teamNamesRequired: 'Ambos nombres de equipo son obligatorios',

--- a/src/lib/i18n/locales/pt.ts
+++ b/src/lib/i18n/locales/pt.ts
@@ -183,6 +183,36 @@ export default {
         twoHours: '2:00 h'
       }
     },
+    remoteConfig: {
+      trigger: 'Configuração do controle remoto',
+      title: 'Controle remoto Bluetooth',
+      description:
+        'Atribua um botão por ação. Os botões de reverter sempre removem apenas a última ação de pontuação daquele time.',
+      helper:
+        'Enquanto estiver escutando, pressione uma vez qualquer botão do controle ou teclado. Salvar com todas as ações vazias remove o mapeamento personalizado.',
+      listening: 'Escutando...',
+      listeningAnnouncement: 'Pressione um botão no seu controle para atribuí-lo a {{action}}.',
+      notSet: 'Não configurado',
+      rows: {
+        singlePressHint: 'Um toque para adicionar um ponto',
+        guardedUndoHint: 'Remove a última ação de pontuação daquele time'
+      },
+      actions: {
+        addTeam1: 'Adicionar Time 1',
+        revertTeam1: 'Reverter Time 1',
+        addTeam2: 'Adicionar Time 2',
+        revertTeam2: 'Reverter Time 2',
+        clear: 'Vínculos vazios',
+        resetDefaults: 'Restaurar padrões',
+        cancel: 'Cancelar',
+        save: 'Salvar'
+      },
+      feedback: {
+        loadError: 'Não foi possível carregar a configuração do controle remoto.',
+        saveError: 'Não foi possível salvar a configuração do controle remoto.',
+        saveSuccess: 'Configuração do controle remoto salva.'
+      }
+    },
     startButton: 'Iniciar Partida',
     validation: {
       teamNamesRequired: 'Ambos os nomes dos times são obrigatórios',

--- a/src/lib/input/index.ts
+++ b/src/lib/input/index.ts
@@ -2,24 +2,49 @@
  * Input Module
  *
  * This module provides utilities for handling user input including keyboard
- * aliases, debouncing, wake lock, and input handlers.
+ * aliases, wake lock, remote controller persistence, and input handlers.
  *
  * @module input
  */
 
-// Re-export keyboard aliases
-export type { KeyboardAction, KeyboardAliasMap } from './keyboard-aliases'
-export { getActionFromKey } from './keyboard-aliases'
+export type {
+  ConfigurableKeyboardAction,
+  KeyboardAction,
+  KeyboardAliasMap,
+  RemoteControllerBindings
+} from './keyboard-aliases'
+export {
+  assignRemoteControllerBinding,
+  configurableKeyboardActions,
+  createEmptyRemoteControllerBindings,
+  createRemoteControllerBindings,
+  defaultRemoteControllerBindings,
+  getActionFromKey,
+  getKeyboardBindingDisplayLabel,
+  normalizeKeyboardBindingKey
+} from './keyboard-aliases'
 
-// Re-export debounce utilities
 export type { DebounceController, CreateDebounceOptions } from './debounce'
 export { createDebounce } from './debounce'
 
-// Re-export wake lock hook
 export { useWakeLock } from './wake-lock'
 export type { UseWakeLockOptions, UseWakeLockReturn } from './wake-lock'
 
-// Re-export input handler hook
+export {
+  clearRemoteControllerBindings,
+  createRemoteControllerStorage,
+  loadRemoteControllerBindings,
+  parseStoredRemoteControllerBindings,
+  remoteControllerStorage,
+  sanitizeRemoteControllerBindings,
+  saveRemoteControllerBindings
+} from './remote-controller-storage'
+export type {
+  RemoteControllerStorage,
+  RemoteControllerStorageOptions,
+  StoredRemoteControllerBindings
+} from './remote-controller-storage'
+
 export { useInputHandler } from './use-input-handler'
 export type {
   UseInputHandlerOptions,

--- a/src/lib/input/index.ts
+++ b/src/lib/input/index.ts
@@ -34,6 +34,7 @@ export {
   clearRemoteControllerBindings,
   createRemoteControllerStorage,
   loadRemoteControllerBindings,
+  loadRemoteControllerBindingsWithFallback,
   parseStoredRemoteControllerBindings,
   remoteControllerStorage,
   sanitizeRemoteControllerBindings,

--- a/src/lib/input/keyboard-aliases.ts
+++ b/src/lib/input/keyboard-aliases.ts
@@ -1,20 +1,29 @@
-export type KeyboardAction = 'score-team-1' | 'score-team-2' | 'undo' | 'unknown'
+export const configurableKeyboardActions = [
+  'add-team-1',
+  'revert-team-1',
+  'add-team-2',
+  'revert-team-2'
+] as const
+
+export type ConfigurableKeyboardAction = (typeof configurableKeyboardActions)[number]
+export type KeyboardAction = ConfigurableKeyboardAction | 'undo' | 'unknown'
+export type RemoteControllerBindings = Record<ConfigurableKeyboardAction, string | null>
 
 export interface KeyboardAliasMap {
   [key: string]: KeyboardAction
 }
 
-const defaultKeyboardAliases: KeyboardAliasMap = {
-  ArrowLeft: 'score-team-1',
-  a: 'score-team-1',
-  1: 'score-team-1',
-  Home: 'score-team-1',
-  PageUp: 'score-team-1',
-  ArrowRight: 'score-team-2',
-  d: 'score-team-2',
-  2: 'score-team-2',
-  End: 'score-team-2',
-  PageDown: 'score-team-2',
+const legacyKeyboardAliases: KeyboardAliasMap = {
+  ArrowLeft: 'add-team-1',
+  a: 'add-team-1',
+  1: 'add-team-1',
+  Home: 'add-team-1',
+  PageUp: 'add-team-1',
+  ArrowRight: 'add-team-2',
+  d: 'add-team-2',
+  2: 'add-team-2',
+  End: 'add-team-2',
+  PageDown: 'add-team-2',
   ArrowUp: 'undo',
   Backspace: 'undo',
   u: 'undo',
@@ -23,8 +32,131 @@ const defaultKeyboardAliases: KeyboardAliasMap = {
   r: 'undo'
 }
 
-export function getActionFromKey(key: string): KeyboardAction {
-  const normalizedKey = key.toLowerCase()
-  const action = defaultKeyboardAliases[key] ?? defaultKeyboardAliases[normalizedKey]
-  return action ?? 'unknown'
+export const defaultRemoteControllerBindings: RemoteControllerBindings = {
+  'add-team-1': 'ArrowLeft',
+  'revert-team-1': 'Backspace',
+  'add-team-2': 'ArrowRight',
+  'revert-team-2': 'Delete'
+}
+
+const keyboardDisplayLabels: Partial<Record<string, string>> = {
+  ' ': 'Space',
+  ArrowDown: '↓ Down',
+  ArrowLeft: '← Left',
+  ArrowRight: '→ Right',
+  ArrowUp: '↑ Up',
+  Backspace: 'Backspace',
+  Delete: 'Delete',
+  End: 'End',
+  Enter: 'Enter',
+  Escape: 'Esc',
+  Home: 'Home',
+  PageDown: 'Page Down',
+  PageUp: 'Page Up',
+  Tab: 'Tab'
+}
+
+export function getActionFromKey(
+  key: string,
+  customBindings?: RemoteControllerBindings | null
+): KeyboardAction {
+  const normalizedKey = normalizeKeyboardBindingKey(key)
+
+  if (!normalizedKey) {
+    return 'unknown'
+  }
+
+  const customAction = getActionFromBindings(normalizedKey, customBindings)
+
+  if (customAction !== 'unknown') {
+    return customAction
+  }
+
+  return legacyKeyboardAliases[normalizedKey] ?? 'unknown'
+}
+
+export function normalizeKeyboardBindingKey(key: string): string {
+  if (!key) {
+    return ''
+  }
+
+  return key.length === 1 ? key.toLowerCase() : key
+}
+
+export function getKeyboardBindingDisplayLabel(key: string | null | undefined): string {
+  if (!key) {
+    return ''
+  }
+
+  if (key.length === 1) {
+    return key === ' ' ? 'Space' : key.toUpperCase()
+  }
+
+  return keyboardDisplayLabels[key] ?? key
+}
+
+export function createEmptyRemoteControllerBindings(): RemoteControllerBindings {
+  const bindings = Object.fromEntries(configurableKeyboardActions.map((action) => [action, null]))
+
+  if (!isRemoteControllerBindingsRecord(bindings)) {
+    throw new Error('Unable to create empty remote controller bindings.')
+  }
+
+  return bindings
+}
+
+function isRemoteControllerBindingsRecord(
+  value: Record<string, unknown>
+): value is RemoteControllerBindings {
+  return configurableKeyboardActions.every((action) => value[action] === null)
+}
+
+export function createRemoteControllerBindings(
+  overrides: Partial<RemoteControllerBindings> = {}
+): RemoteControllerBindings {
+  return {
+    ...defaultRemoteControllerBindings,
+    ...overrides
+  }
+}
+
+export function assignRemoteControllerBinding(
+  currentBindings: RemoteControllerBindings,
+  action: ConfigurableKeyboardAction,
+  key: string
+): RemoteControllerBindings {
+  const nextBindings = { ...currentBindings }
+  const normalizedNewKey = normalizeKeyboardBindingKey(key)
+
+  for (const currentAction of configurableKeyboardActions) {
+    if (currentAction !== action) {
+      const existingKey = nextBindings[currentAction]
+      if (existingKey && normalizeKeyboardBindingKey(existingKey) === normalizedNewKey) {
+        nextBindings[currentAction] = null
+      }
+    }
+  }
+
+  nextBindings[action] = key
+
+  return nextBindings
+}
+
+function getActionFromBindings(
+  normalizedKey: string,
+  bindings?: RemoteControllerBindings | null
+): KeyboardAction {
+  if (!bindings) {
+    return 'unknown'
+  }
+
+  for (const action of configurableKeyboardActions) {
+    const configuredKey = bindings[action]
+
+    if (configuredKey && normalizeKeyboardBindingKey(configuredKey) === normalizedKey) {
+      return action
+    }
+  }
+
+  return 'unknown'
 }

--- a/src/lib/input/remote-controller-storage.ts
+++ b/src/lib/input/remote-controller-storage.ts
@@ -1,0 +1,151 @@
+import {
+  remoteControllerPreferenceObjectStoreName,
+  resolveIndexedDbStorageConfig,
+  waitForIndexedDbRequest,
+  waitForIndexedDbTransaction,
+  withIndexedDbDatabase,
+  type IndexedDbOpenMessages
+} from '@/lib/persistence/indexed-db'
+
+import {
+  configurableKeyboardActions,
+  createEmptyRemoteControllerBindings,
+  type RemoteControllerBindings,
+  normalizeKeyboardBindingKey
+} from './keyboard-aliases'
+
+const defaultObjectStoreName = remoteControllerPreferenceObjectStoreName
+const remoteControllerBindingsKey = 'remote-controller-bindings'
+
+const indexedDbMessages: IndexedDbOpenMessages = {
+  blocked: 'Opening the remote controller database was blocked.',
+  openFailed: 'Unable to open the remote controller database.'
+}
+
+export interface RemoteControllerStorageOptions {
+  databaseName?: string
+  databaseVersion?: number
+  objectStoreName?: string
+}
+
+export interface StoredRemoteControllerBindings {
+  bindings: RemoteControllerBindings
+  updatedAt: string
+}
+
+export interface RemoteControllerStorage {
+  saveRemoteControllerBindings(bindings: RemoteControllerBindings): Promise<void>
+  loadRemoteControllerBindings(): Promise<RemoteControllerBindings | null>
+  clearRemoteControllerBindings(): Promise<void>
+}
+
+export function createRemoteControllerStorage(
+  options: RemoteControllerStorageOptions = {}
+): RemoteControllerStorage {
+  const config = resolveIndexedDbStorageConfig(options, defaultObjectStoreName)
+
+  const saveRemoteControllerBindings = async (
+    bindings: RemoteControllerBindings
+  ): Promise<void> => {
+    const record: StoredRemoteControllerBindings = {
+      bindings: sanitizeRemoteControllerBindings(bindings),
+      updatedAt: new Date().toISOString()
+    }
+
+    await withIndexedDbDatabase(config, indexedDbMessages, async (database) => {
+      const transaction = database.transaction(config.objectStoreName, 'readwrite')
+
+      transaction.objectStore(config.objectStoreName).put(record, remoteControllerBindingsKey)
+      await waitForIndexedDbTransaction(transaction)
+    })
+  }
+
+  const loadRemoteControllerBindings = async (): Promise<RemoteControllerBindings | null> => {
+    return withIndexedDbDatabase(config, indexedDbMessages, async (database) => {
+      const transaction = database.transaction(config.objectStoreName, 'readonly')
+      const request = transaction
+        .objectStore(config.objectStoreName)
+        .get(remoteControllerBindingsKey)
+      const storedRecord = await waitForIndexedDbRequest<
+        StoredRemoteControllerBindings | undefined
+      >(request)
+
+      await waitForIndexedDbTransaction(transaction)
+
+      if (!storedRecord) {
+        return null
+      }
+
+      return parseStoredRemoteControllerBindings(storedRecord)
+    })
+  }
+
+  const clearRemoteControllerBindings = async (): Promise<void> => {
+    await withIndexedDbDatabase(config, indexedDbMessages, async (database) => {
+      const transaction = database.transaction(config.objectStoreName, 'readwrite')
+
+      transaction.objectStore(config.objectStoreName).delete(remoteControllerBindingsKey)
+      await waitForIndexedDbTransaction(transaction)
+    })
+  }
+
+  return {
+    saveRemoteControllerBindings,
+    loadRemoteControllerBindings,
+    clearRemoteControllerBindings
+  }
+}
+
+export function parseStoredRemoteControllerBindings(
+  value: unknown
+): RemoteControllerBindings | null {
+  if (!isStoredRemoteControllerBindings(value)) {
+    return null
+  }
+
+  return sanitizeRemoteControllerBindings(value.bindings)
+}
+
+export function sanitizeRemoteControllerBindings(
+  bindings: Partial<RemoteControllerBindings>
+): RemoteControllerBindings {
+  const sanitizedBindings = createEmptyRemoteControllerBindings()
+
+  for (const action of configurableKeyboardActions) {
+    const value = bindings[action]
+
+    sanitizedBindings[action] =
+      typeof value === 'string' && normalizeKeyboardBindingKey(value) ? value : null
+  }
+
+  return sanitizedBindings
+}
+
+function isStoredRemoteControllerBindings(value: unknown): value is StoredRemoteControllerBindings {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const candidate = value as Partial<StoredRemoteControllerBindings>
+
+  if (!candidate.bindings || typeof candidate.bindings !== 'object') {
+    return false
+  }
+
+  if (typeof candidate.updatedAt !== 'string') {
+    return false
+  }
+
+  return configurableKeyboardActions.every((action) => {
+    const binding = candidate.bindings?.[action]
+    return binding === null || typeof binding === 'string'
+  })
+}
+
+export const remoteControllerStorage = createRemoteControllerStorage()
+export const saveRemoteControllerBindings = (bindings: RemoteControllerBindings) =>
+  remoteControllerStorage.saveRemoteControllerBindings(bindings)
+export const loadRemoteControllerBindings = () =>
+  remoteControllerStorage.loadRemoteControllerBindings()
+export const clearRemoteControllerBindings = () =>
+  remoteControllerStorage.clearRemoteControllerBindings()

--- a/src/lib/input/remote-controller-storage.ts
+++ b/src/lib/input/remote-controller-storage.ts
@@ -39,6 +39,12 @@ export interface RemoteControllerStorage {
   clearRemoteControllerBindings(): Promise<void>
 }
 
+export async function loadRemoteControllerBindingsWithFallback(): Promise<RemoteControllerBindings> {
+  const storedBindings = await loadRemoteControllerBindings()
+
+  return storedBindings ?? createEmptyRemoteControllerBindings()
+}
+
 export function createRemoteControllerStorage(
   options: RemoteControllerStorageOptions = {}
 ): RemoteControllerStorage {

--- a/src/lib/input/use-input-handler.tsx
+++ b/src/lib/input/use-input-handler.tsx
@@ -109,7 +109,7 @@ export function useInputHandler(
   const cancelPendingAdd = useCallback((teamId: MatchTeamId): boolean => {
     const timer = pendingAddTimersRef.current[teamId]
 
-    if (!timer) {
+    if (timer === null) {
       return false
     }
 

--- a/src/lib/input/use-input-handler.tsx
+++ b/src/lib/input/use-input-handler.tsx
@@ -49,6 +49,8 @@ export function useInputHandler(
 
   const callbacksRef = useRef(callbacks)
   const bindingsRef = useRef<RemoteControllerBindings | null>(bindings)
+  const actionsRef = useRef(options.actions)
+  const enabledRef = useRef(enabled)
   const pendingAddTimersRef = useRef<Record<MatchTeamId, ReturnType<typeof setTimeout> | null>>({
     'team-1': null,
     'team-2': null
@@ -56,6 +58,8 @@ export function useInputHandler(
 
   callbacksRef.current = callbacks
   bindingsRef.current = bindings
+  actionsRef.current = options.actions
+  enabledRef.current = enabled
 
   const onWakeLockError = useCallback((error: Error) => {
     callbacksRef.current.onError?.(error)
@@ -85,6 +89,15 @@ export function useInputHandler(
   }, [])
 
   const undoForTeam = useCallback(async (teamId: MatchTeamId) => {
+    // MatchAction is currently ScorePointAction only; guard is future-proof if new action types are added
+    const hasScoringAction = actionsRef.current.some(
+      (action) => action.type === 'score-point' && action.teamId === teamId
+    )
+
+    if (!hasScoringAction) {
+      return
+    }
+
     try {
       await callbacksRef.current.onUndoForTeam(teamId)
     } catch (err) {
@@ -122,6 +135,11 @@ export function useInputHandler(
 
       pendingAddTimersRef.current[teamId] = setTimeout(() => {
         pendingAddTimersRef.current[teamId] = null
+
+        if (!enabledRef.current) {
+          return
+        }
+
         void scorePoint(teamId)
       }, bufferedAddWindowMs)
     },
@@ -204,7 +222,10 @@ export function useInputHandler(
   }, [enabled, undo])
 
   useEffect(() => {
+    // enabledRef is already current from the render body (synchronous assignment above).
+    // cancelAllPendingAdds() is the important cleanup here.
     if (!enabled) {
+      cancelAllPendingAdds()
       return
     }
 
@@ -213,7 +234,7 @@ export function useInputHandler(
     return () => {
       window.removeEventListener('keydown', onKeyDown)
     }
-  }, [enabled, onKeyDown])
+  }, [cancelAllPendingAdds, enabled, onKeyDown])
 
   useEffect(() => {
     return () => {

--- a/src/lib/input/use-input-handler.tsx
+++ b/src/lib/input/use-input-handler.tsx
@@ -2,21 +2,25 @@
 
 import { useCallback, useEffect, useRef } from 'react'
 
-import type { MatchTeamId } from '@/core/match'
-import type { CurrentMatchSession } from '@/lib/current-match/session'
-import { createDebounce, type DebounceController } from './debounce'
-import { getActionFromKey, type KeyboardAction } from './keyboard-aliases'
+import type { MatchAction, MatchTeamId } from '@/core/match'
+
+import { getActionFromKey, type RemoteControllerBindings } from './keyboard-aliases'
 import { type UseWakeLockReturn, useWakeLock } from './wake-lock'
 
+const defaultBufferedAddWindowMs = 380
+
 export interface UseInputHandlerOptions {
-  session: CurrentMatchSession
+  actions: MatchAction[]
+  bindings?: RemoteControllerBindings | null
   enabled?: boolean
   useWakeLock?: boolean
+  bufferedAddWindowMs?: number
 }
 
 export interface UseInputHandlerCallbacks {
-  onScore?: (teamId: MatchTeamId) => void
-  onUndo?: () => void
+  onAdd: (teamId: MatchTeamId) => Promise<void> | void
+  onUndo: () => Promise<void> | void
+  onUndoForTeam: (teamId: MatchTeamId) => Promise<void> | void
   onError?: (error: Error) => void
 }
 
@@ -34,28 +38,27 @@ export interface UseInputHandlerReturn {
 
 export function useInputHandler(
   options: UseInputHandlerOptions,
-  callbacks?: UseInputHandlerCallbacks
+  callbacks: UseInputHandlerCallbacks
 ): UseInputHandlerReturn {
-  const { session, enabled = true, useWakeLock: useWakeLockEnabled = false } = options
+  const {
+    bindings = null,
+    enabled = true,
+    useWakeLock: useWakeLockEnabled = false,
+    bufferedAddWindowMs = defaultBufferedAddWindowMs
+  } = options
 
-  const debounceRef = useRef<DebounceController | null>(null)
-  const callbacksRef = useRef<UseInputHandlerCallbacks | undefined>(callbacks)
-  const sessionRef = useRef(session)
+  const callbacksRef = useRef(callbacks)
+  const bindingsRef = useRef<RemoteControllerBindings | null>(bindings)
+  const pendingAddTimersRef = useRef<Record<MatchTeamId, ReturnType<typeof setTimeout> | null>>({
+    'team-1': null,
+    'team-2': null
+  })
 
-  // Keep refs up to date
   callbacksRef.current = callbacks
-  sessionRef.current = session
-
-  // Create debounce lazily on mount
-  useEffect(() => {
-    debounceRef.current = createDebounce({ delay: 300 })
-    return () => {
-      debounceRef.current?.cleanup()
-    }
-  }, [])
+  bindingsRef.current = bindings
 
   const onWakeLockError = useCallback((error: Error) => {
-    callbacksRef.current?.onError?.(error)
+    callbacksRef.current.onError?.(error)
   }, [])
 
   const wakeLock = useWakeLock({
@@ -65,48 +68,64 @@ export function useInputHandler(
 
   const scorePoint = useCallback(async (teamId: MatchTeamId) => {
     try {
-      await sessionRef.current.scorePoint(teamId)
-      callbacksRef.current?.onScore?.(teamId)
+      await callbacksRef.current.onAdd(teamId)
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err))
-      callbacksRef.current?.onError?.(error)
+      callbacksRef.current.onError?.(error)
     }
   }, [])
 
   const undo = useCallback(async () => {
     try {
-      await sessionRef.current.undoScoreAction()
-      callbacksRef.current?.onUndo?.()
+      await callbacksRef.current.onUndo()
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err))
-      callbacksRef.current?.onError?.(error)
+      callbacksRef.current.onError?.(error)
     }
   }, [])
 
-  const handleAction = useCallback(
-    (action: KeyboardAction) => {
-      switch (action) {
-        case 'score-team-1':
-          if (debounceRef.current?.isReady()) {
-            debounceRef.current.trigger()
-            void scorePoint('team-1')
-          }
-          break
-        case 'score-team-2':
-          if (debounceRef.current?.isReady()) {
-            debounceRef.current.trigger()
-            void scorePoint('team-2')
-          }
-          break
-        case 'undo':
-          void undo()
-          break
-        case 'unknown':
-        default:
-          break
+  const undoForTeam = useCallback(async (teamId: MatchTeamId) => {
+    try {
+      await callbacksRef.current.onUndoForTeam(teamId)
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err))
+      callbacksRef.current.onError?.(error)
+    }
+  }, [])
+
+  const cancelPendingAdd = useCallback((teamId: MatchTeamId): boolean => {
+    const timer = pendingAddTimersRef.current[teamId]
+
+    if (!timer) {
+      return false
+    }
+
+    clearTimeout(timer)
+    pendingAddTimersRef.current[teamId] = null
+    return true
+  }, [])
+
+  const cancelAllPendingAdds = useCallback((): boolean => {
+    const cancelledTeam1 = cancelPendingAdd('team-1')
+    const cancelledTeam2 = cancelPendingAdd('team-2')
+
+    return cancelledTeam1 || cancelledTeam2
+  }, [cancelPendingAdd])
+
+  const queueBufferedAdd = useCallback(
+    (teamId: MatchTeamId) => {
+      if (pendingAddTimersRef.current[teamId]) {
+        cancelPendingAdd(teamId)
+        void undoForTeam(teamId)
+        return
       }
+
+      pendingAddTimersRef.current[teamId] = setTimeout(() => {
+        pendingAddTimersRef.current[teamId] = null
+        void scorePoint(teamId)
+      }, bufferedAddWindowMs)
     },
-    [scorePoint, undo]
+    [bufferedAddWindowMs, cancelPendingAdd, scorePoint, undoForTeam]
   )
 
   const onKeyDown = useCallback(
@@ -115,49 +134,72 @@ export function useInputHandler(
         return
       }
 
-      // Don't handle keys when modifier keys are pressed to avoid breaking browser shortcuts
       if (event.ctrlKey || event.metaKey || event.altKey) {
         return
       }
 
-      const target = event.target
-      if (
-        target instanceof HTMLElement &&
-        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
-      ) {
+      if (isEditableTarget(event.target)) {
         return
       }
 
-      const action = getActionFromKey(event.key)
+      const action = getActionFromKey(event.key, bindingsRef.current)
 
-      // Prevent default browser behavior for handled keys to avoid navigation/scrolling
-      if (action !== 'unknown') {
-        event.preventDefault()
+      if (action === 'unknown') {
+        return
       }
 
-      handleAction(action)
+      event.preventDefault()
+
+      switch (action) {
+        case 'add-team-1':
+          queueBufferedAdd('team-1')
+          break
+        case 'add-team-2':
+          queueBufferedAdd('team-2')
+          break
+        case 'revert-team-1':
+          cancelPendingAdd('team-1')
+          void undoForTeam('team-1')
+          break
+        case 'revert-team-2':
+          cancelPendingAdd('team-2')
+          void undoForTeam('team-2')
+          break
+        case 'undo':
+          // Undo cancels buffered adds first so a queued remote score cannot still commit
+          // after the user asks to reverse the latest action.
+          if (!cancelAllPendingAdds()) {
+            void undo()
+          }
+          break
+        default:
+          break
+      }
     },
-    [enabled, handleAction]
+    [cancelAllPendingAdds, cancelPendingAdd, enabled, queueBufferedAdd, undo, undoForTeam]
   )
 
   const onTeam1Score = useCallback(() => {
-    if (!enabled) return
-    if (debounceRef.current?.isReady()) {
-      debounceRef.current.trigger()
-      void scorePoint('team-1')
+    if (!enabled) {
+      return
     }
+
+    void scorePoint('team-1')
   }, [enabled, scorePoint])
 
   const onTeam2Score = useCallback(() => {
-    if (!enabled) return
-    if (debounceRef.current?.isReady()) {
-      debounceRef.current.trigger()
-      void scorePoint('team-2')
+    if (!enabled) {
+      return
     }
+
+    void scorePoint('team-2')
   }, [enabled, scorePoint])
 
   const onUndoHandler = useCallback(() => {
-    if (!enabled) return
+    if (!enabled) {
+      return
+    }
+
     void undo()
   }, [enabled, undo])
 
@@ -172,6 +214,12 @@ export function useInputHandler(
       window.removeEventListener('keydown', onKeyDown)
     }
   }, [enabled, onKeyDown])
+
+  useEffect(() => {
+    return () => {
+      cancelAllPendingAdds()
+    }
+  }, [cancelAllPendingAdds])
 
   return {
     scorePoint,
@@ -188,4 +236,12 @@ export function useInputHandler(
       error: wakeLock.error
     }
   }
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+
+  return target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable
 }

--- a/src/lib/persistence/indexed-db.ts
+++ b/src/lib/persistence/indexed-db.ts
@@ -1,14 +1,16 @@
 export const persistenceDatabaseName = 'padel-buddy-web'
-export const persistenceDatabaseVersion = 4
+export const persistenceDatabaseVersion = 5
 
 export const currentMatchObjectStoreName = 'current-match'
 export const localePreferenceObjectStoreName = 'locale-preference'
 export const speechPreferenceObjectStoreName = 'speech-preference'
+export const remoteControllerPreferenceObjectStoreName = 'remote-controller-preference'
 
 export const sharedIndexedDbObjectStoreNames = [
   currentMatchObjectStoreName,
   localePreferenceObjectStoreName,
-  speechPreferenceObjectStoreName
+  speechPreferenceObjectStoreName,
+  remoteControllerPreferenceObjectStoreName
 ] as const
 
 export interface IndexedDbStorageOptions {

--- a/test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx
+++ b/test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx
@@ -6,7 +6,9 @@ import { render } from 'vitest-browser-react'
 
 import { ActiveMatchScreen } from '@/components/ActiveMatchScreen/ActiveMatchScreen'
 import teamPanelStyles from '@/components/ActiveMatchScreen/TeamPanel/TeamPanel.module.css'
-import { createTestSetup, winQuickSet } from '../../core/match/test-helpers'
+import { createRemoteControllerBindings } from '@/lib/input'
+
+import { createTestSetup, scorePoints, winQuickSet } from '../../core/match/test-helpers'
 import { resolveCssColor } from '../../utils/css'
 
 function formatTimeOfDay(date: Date): string {
@@ -15,11 +17,13 @@ function formatTimeOfDay(date: Date): string {
     .join(':')
 }
 
-const { mockInvalidate, mockNavigate, mockPreloadRoute } = vi.hoisted(() => ({
-  mockInvalidate: vi.fn(async () => undefined),
-  mockNavigate: vi.fn(),
-  mockPreloadRoute: vi.fn(async () => undefined)
-}))
+const { mockInvalidate, mockNavigate, mockPreloadRoute, mockLoadRemoteControllerBindings } =
+  vi.hoisted(() => ({
+    mockInvalidate: vi.fn(async () => undefined),
+    mockNavigate: vi.fn(),
+    mockPreloadRoute: vi.fn(async () => undefined),
+    mockLoadRemoteControllerBindings: vi.fn()
+  }))
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
@@ -44,6 +48,15 @@ vi.mock('@/lib/i18n', async (importOriginal) => {
   }
 })
 
+vi.mock('@/lib/input', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/input')>()
+
+  return {
+    ...actual,
+    loadRemoteControllerBindings: mockLoadRemoteControllerBindings
+  }
+})
+
 describe('ActiveMatchScreen', () => {
   const defaultStartedAt = Date.now() - 5 * 60 * 1000
 
@@ -51,6 +64,7 @@ describe('ActiveMatchScreen', () => {
     vi.clearAllMocks()
     mockInvalidate.mockResolvedValue(undefined)
     mockPreloadRoute.mockResolvedValue(undefined)
+    mockLoadRemoteControllerBindings.mockResolvedValue(null)
   })
 
   afterEach(() => {
@@ -59,18 +73,18 @@ describe('ActiveMatchScreen', () => {
   })
 
   test('renders with initial state', async () => {
-    const setup = createTestSetup()
-
     const screen = await render(
       <ActiveMatchScreen
         matchId="test-match"
-        initialSetup={setup}
+        initialSetup={createTestSetup()}
         initialActions={[]}
         startedAt={defaultStartedAt}
       />
     )
 
     await expect.element(screen.getByTestId('layout-body')).toBeInTheDocument()
+    await expect.element(screen.getByTestId('team-panel-team-1')).toBeInTheDocument()
+    await expect.element(screen.getByTestId('team-panel-team-2')).toBeInTheDocument()
   })
 
   test('renders team names', async () => {
@@ -95,12 +109,10 @@ describe('ActiveMatchScreen', () => {
   })
 
   test('renders team panels', async () => {
-    const setup = createTestSetup()
-
     const screen = await render(
       <ActiveMatchScreen
         matchId="test-match"
-        initialSetup={setup}
+        initialSetup={createTestSetup()}
         initialActions={[]}
         startedAt={defaultStartedAt}
       />
@@ -111,12 +123,10 @@ describe('ActiveMatchScreen', () => {
   })
 
   test('renders sets card without the info card overlay', async () => {
-    const setup = createTestSetup()
-
     const screen = await render(
       <ActiveMatchScreen
         matchId="test-match"
-        initialSetup={setup}
+        initialSetup={createTestSetup()}
         initialActions={[]}
         startedAt={defaultStartedAt}
       />
@@ -130,12 +140,10 @@ describe('ActiveMatchScreen', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-21T12:00:00.000Z'))
 
-    const setup = createTestSetup()
-
     const screen = await render(
       <ActiveMatchScreen
         matchId="test-match"
-        initialSetup={setup}
+        initialSetup={createTestSetup()}
         initialActions={[]}
         startedAt={defaultStartedAt}
       />
@@ -173,14 +181,10 @@ describe('ActiveMatchScreen', () => {
   })
 
   test('highlights the serving team panel when the serving indicator is enabled', async () => {
-    const setup = createTestSetup({
-      servingIndicatorEnabled: true
-    })
-
     const screen = await render(
       <ActiveMatchScreen
         matchId="test-match"
-        initialSetup={setup}
+        initialSetup={createTestSetup({ servingIndicatorEnabled: true })}
         initialActions={[]}
         startedAt={defaultStartedAt}
       />
@@ -205,14 +209,10 @@ describe('ActiveMatchScreen', () => {
   })
 
   test('does not highlight team panels when the serving indicator is disabled', async () => {
-    const setup = createTestSetup({
-      servingIndicatorEnabled: false
-    })
-
     const screen = await render(
       <ActiveMatchScreen
         matchId="test-match"
-        initialSetup={setup}
+        initialSetup={createTestSetup({ servingIndicatorEnabled: false })}
         initialActions={[]}
         startedAt={defaultStartedAt}
       />
@@ -227,16 +227,15 @@ describe('ActiveMatchScreen', () => {
   })
 
   test('uses the countdown timer aria-label when countdown mode is enabled', async () => {
-    const setup = createTestSetup({
-      countdownTimerEnabled: true,
-      countdownTimerDuration: 60
-    })
     const startedAt = Date.now() - 5 * 60 * 1000
 
     const screen = await render(
       <ActiveMatchScreen
         matchId="test-match"
-        initialSetup={setup}
+        initialSetup={createTestSetup({
+          countdownTimerEnabled: true,
+          countdownTimerDuration: 60
+        })}
         initialActions={[]}
         startedAt={startedAt}
       />
@@ -248,12 +247,10 @@ describe('ActiveMatchScreen', () => {
   })
 
   test('renders revert buttons', async () => {
-    const setup = createTestSetup()
-
     const screen = await render(
       <ActiveMatchScreen
         matchId="test-match"
-        initialSetup={setup}
+        initialSetup={createTestSetup()}
         initialActions={[]}
         startedAt={defaultStartedAt}
       />
@@ -264,12 +261,10 @@ describe('ActiveMatchScreen', () => {
   })
 
   test('renders finish button', async () => {
-    const setup = createTestSetup()
-
     const screen = await render(
       <ActiveMatchScreen
         matchId="test-match"
-        initialSetup={setup}
+        initialSetup={createTestSetup()}
         initialActions={[]}
         startedAt={defaultStartedAt}
       />
@@ -279,12 +274,10 @@ describe('ActiveMatchScreen', () => {
   })
 
   test('finish button stays enabled when match is not completed', async () => {
-    const setup = createTestSetup()
-
     const screen = await render(
       <ActiveMatchScreen
         matchId="test-match"
-        initialSetup={setup}
+        initialSetup={createTestSetup()}
         initialActions={[]}
         startedAt={defaultStartedAt}
       />
@@ -293,55 +286,11 @@ describe('ActiveMatchScreen', () => {
     await expect.element(screen.getByTestId('finish-button')).toBeEnabled()
   })
 
-  test('scoring updates team score', async () => {
-    const setup = createTestSetup()
-
+  test('touch scoring updates the team score immediately', async () => {
     const screen = await render(
       <ActiveMatchScreen
         matchId="test-match"
-        initialSetup={setup}
-        initialActions={[]}
-        startedAt={defaultStartedAt}
-      />
-    )
-
-    const team1Panel = screen.getByTestId('team-panel-team-1')
-    const scoreElement = team1Panel.element().querySelector('[aria-live="polite"]')
-    expect(scoreElement?.textContent).toBe('0')
-
-    ;(team1Panel.element() as HTMLButtonElement).click()
-
-    await vi.waitFor(() => {
-      const newScoreElement = screen
-        .getByTestId('team-panel-team-1')
-        .element()
-        .querySelector('[aria-live="polite"]')
-      return expect(newScoreElement?.textContent).toBe('15')
-    })
-  })
-
-  test('revert button is disabled when no actions', async () => {
-    const setup = createTestSetup()
-
-    const screen = await render(
-      <ActiveMatchScreen
-        matchId="test-match"
-        initialSetup={setup}
-        initialActions={[]}
-        startedAt={defaultStartedAt}
-      />
-    )
-
-    await expect.element(screen.getByTestId('revert-button-team-1')).toBeDisabled()
-  })
-
-  test('revert button removes the last point for both team controls', async () => {
-    const setup = createTestSetup()
-
-    const screen = await render(
-      <ActiveMatchScreen
-        matchId="test-match"
-        initialSetup={setup}
+        initialSetup={createTestSetup()}
         initialActions={[]}
         startedAt={defaultStartedAt}
       />
@@ -350,33 +299,201 @@ describe('ActiveMatchScreen', () => {
     await screen.getByTestId('team-panel-team-1').click()
 
     await vi.waitFor(() => {
-      const scoreElement = screen
-        .getByTestId('team-panel-team-1')
-        .element()
-        .querySelector('[aria-live="polite"]')
-      return expect(scoreElement?.textContent).toBe('15')
+      expect(readDisplayedScore(screen, 'team-1')).toBe('15')
     })
+  })
 
-    await screen.getByTestId('revert-button-team-2').click()
+  test('team-specific revert buttons are disabled independently', async () => {
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={scorePoints('team-1')}
+        startedAt={defaultStartedAt}
+      />
+    )
+
+    await expect.element(screen.getByTestId('revert-button-team-1')).toBeEnabled()
+    await expect.element(screen.getByTestId('revert-button-team-2')).toBeDisabled()
+  })
+
+  test('revert button removes the last point for its own team only', async () => {
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={scorePoints('team-1', 'team-2')}
+        startedAt={defaultStartedAt}
+      />
+    )
+
+    await screen.getByTestId('revert-button-team-1').click()
 
     await vi.waitFor(() => {
-      const scoreElement = screen
-        .getByTestId('team-panel-team-1')
-        .element()
-        .querySelector('[aria-live="polite"]')
-      return expect(scoreElement?.textContent).toBe('0')
+      expect(readDisplayedScore(screen, 'team-1')).toBe('0')
+      expect(readDisplayedScore(screen, 'team-2')).toBe('15')
+    })
+  })
+
+  test('loads saved remote bindings on mount', async () => {
+    await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={[]}
+        startedAt={defaultStartedAt}
+      />
+    )
+
+    await vi.waitFor(() => {
+      expect(mockLoadRemoteControllerBindings).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  test('legacy Backspace continues to undo when no remote is configured', async () => {
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={scorePoints('team-1')}
+        startedAt={defaultStartedAt}
+      />
+    )
+
+    await vi.waitFor(() => {
+      expect(mockLoadRemoteControllerBindings).toHaveBeenCalledTimes(1)
+    })
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace' }))
+
+    await vi.waitFor(() => {
+      expect(readDisplayedScore(screen, 'team-1')).toBe('0')
+    })
+  })
+
+  test('legacy Delete continues to undo when no remote is configured', async () => {
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={scorePoints('team-2')}
+        startedAt={defaultStartedAt}
+      />
+    )
+
+    await vi.waitFor(() => {
+      expect(mockLoadRemoteControllerBindings).toHaveBeenCalledTimes(1)
+    })
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete' }))
+
+    await vi.waitFor(() => {
+      expect(readDisplayedScore(screen, 'team-2')).toBe('0')
+    })
+  })
+
+  test('mapped remote add waits for the buffered window before scoring', async () => {
+    vi.useFakeTimers()
+    mockLoadRemoteControllerBindings.mockResolvedValue(
+      createRemoteControllerBindings({
+        'add-team-1': 'q',
+        'revert-team-1': 'z',
+        'add-team-2': 'w',
+        'revert-team-2': 'x'
+      })
+    )
+
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={[]}
+        startedAt={defaultStartedAt}
+      />
+    )
+
+    await vi.waitFor(() => {
+      expect(mockLoadRemoteControllerBindings).toHaveBeenCalledTimes(1)
+    })
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'q' }))
+    expect(readDisplayedScore(screen, 'team-1')).toBe('0')
+
+    await vi.advanceTimersByTimeAsync(380)
+
+    await vi.waitFor(() => {
+      expect(readDisplayedScore(screen, 'team-1')).toBe('15')
+    })
+  })
+
+  test('remote team-specific revert removes the last score for that team', async () => {
+    mockLoadRemoteControllerBindings.mockResolvedValue(
+      createRemoteControllerBindings({
+        'add-team-1': 'q',
+        'revert-team-1': 'z',
+        'add-team-2': 'w',
+        'revert-team-2': 'x'
+      })
+    )
+
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={scorePoints('team-1', 'team-2')}
+        startedAt={defaultStartedAt}
+      />
+    )
+
+    await vi.waitFor(() => {
+      expect(mockLoadRemoteControllerBindings).toHaveBeenCalledTimes(1)
+    })
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z' }))
+
+    await vi.waitFor(() => {
+      expect(readDisplayedScore(screen, 'team-1')).toBe('0')
+      expect(readDisplayedScore(screen, 'team-2')).toBe('15')
+    })
+  })
+
+  test('remote team-specific revert leaves the score unchanged when that team has no actions', async () => {
+    mockLoadRemoteControllerBindings.mockResolvedValue(
+      createRemoteControllerBindings({
+        'add-team-1': 'q',
+        'revert-team-1': 'z',
+        'add-team-2': 'w',
+        'revert-team-2': 'x'
+      })
+    )
+
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={scorePoints('team-2')}
+        startedAt={defaultStartedAt}
+      />
+    )
+
+    await vi.waitFor(() => {
+      expect(mockLoadRemoteControllerBindings).toHaveBeenCalledTimes(1)
+    })
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z' }))
+
+    await vi.waitFor(() => {
+      expect(readDisplayedScore(screen, 'team-1')).toBe('0')
+      expect(readDisplayedScore(screen, 'team-2')).toBe('15')
     })
   })
 
   test('navigates to the finish route when the match is completed', async () => {
-    const setup = createTestSetup()
-    const actions = [...winQuickSet('team-1'), ...winQuickSet('team-1')]
-
     await render(
       <ActiveMatchScreen
         matchId="test-match"
-        initialSetup={setup}
-        initialActions={actions}
+        initialSetup={createTestSetup()}
+        initialActions={[...winQuickSet('team-1'), ...winQuickSet('team-1')]}
         startedAt={defaultStartedAt}
       />
     )
@@ -393,12 +510,10 @@ describe('ActiveMatchScreen', () => {
   })
 
   test('clicking finish marks the match finished and navigates to the finish route', async () => {
-    const setup = createTestSetup()
-
     const screen = await render(
       <ActiveMatchScreen
         matchId="test-match"
-        initialSetup={setup}
+        initialSetup={createTestSetup()}
         initialActions={[]}
         startedAt={defaultStartedAt}
       />
@@ -418,14 +533,11 @@ describe('ActiveMatchScreen', () => {
   })
 
   test('team panels are disabled when match is completed', async () => {
-    const setup = createTestSetup()
-    const actions = [...winQuickSet('team-1'), ...winQuickSet('team-1')]
-
     const screen = await render(
       <ActiveMatchScreen
         matchId="test-match"
-        initialSetup={setup}
-        initialActions={actions}
+        initialSetup={createTestSetup()}
+        initialActions={[...winQuickSet('team-1'), ...winQuickSet('team-1')]}
         startedAt={defaultStartedAt}
       />
     )
@@ -435,14 +547,11 @@ describe('ActiveMatchScreen', () => {
   })
 
   test('finish button is disabled when match is already completed', async () => {
-    const setup = createTestSetup()
-    const actions = [...winQuickSet('team-1'), ...winQuickSet('team-1')]
-
     const screen = await render(
       <ActiveMatchScreen
         matchId="test-match"
-        initialSetup={setup}
-        initialActions={actions}
+        initialSetup={createTestSetup()}
+        initialActions={[...winQuickSet('team-1'), ...winQuickSet('team-1')]}
         startedAt={defaultStartedAt}
       />
     )
@@ -450,3 +559,13 @@ describe('ActiveMatchScreen', () => {
     await expect.element(screen.getByTestId('finish-button')).toBeDisabled()
   })
 })
+
+function readDisplayedScore(
+  screen: Awaited<ReturnType<typeof render>>,
+  teamId: 'team-1' | 'team-2'
+): string {
+  return (
+    screen.getByTestId(`team-panel-${teamId}`).element().querySelector('[aria-live="polite"]')
+      ?.textContent ?? ''
+  )
+}

--- a/test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx
+++ b/test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx
@@ -53,7 +53,7 @@ vi.mock('@/lib/input', async (importOriginal) => {
 
   return {
     ...actual,
-    loadRemoteControllerBindings: mockLoadRemoteControllerBindings
+    loadRemoteControllerBindingsWithFallback: mockLoadRemoteControllerBindings
   }
 })
 

--- a/test/components/ActiveMatchScreen/useMatchSession.browser.test.tsx
+++ b/test/components/ActiveMatchScreen/useMatchSession.browser.test.tsx
@@ -51,6 +51,20 @@ function SessionTestComponent({
       <button type="button" data-testid="undo" onClick={() => state.undoScoreAction()}>
         Undo
       </button>
+      <button
+        type="button"
+        data-testid="undo-team-1"
+        onClick={() => state.undoScoreActionForTeam('team-1')}
+      >
+        Undo Team 1
+      </button>
+      <button
+        type="button"
+        data-testid="undo-team-2"
+        onClick={() => state.undoScoreActionForTeam('team-2')}
+      >
+        Undo Team 2
+      </button>
     </div>
   )
 }
@@ -179,6 +193,49 @@ describe('useMatchSession', () => {
 
     // Should still be 0
     await expect.element(screen.getByTestId('actionCount')).toHaveTextContent('0')
+  })
+
+  test('undoScoreActionForTeam removes the last action for the selected team', async () => {
+    const setup = createTestSetup()
+    const initialActions = [
+      { type: 'score-point' as const, teamId: 'team-1' as const },
+      { type: 'score-point' as const, teamId: 'team-2' as const },
+      { type: 'score-point' as const, teamId: 'team-1' as const }
+    ]
+
+    const screen = await render(
+      <SessionTestComponent
+        setup={setup}
+        initialActions={initialActions}
+        startedAt={defaultStartedAt}
+        persistence={mockPersistence}
+      />
+    )
+
+    await expect.element(screen.getByTestId('actionCount')).toHaveTextContent('3')
+
+    await screen.getByTestId('undo-team-1').click()
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('actionCount').element().textContent).toBe('2')
+    })
+  })
+
+  test('undoScoreActionForTeam keeps the snapshot unchanged when the selected team has no actions', async () => {
+    const setup = createTestSetup()
+
+    const screen = await render(
+      <SessionTestComponent
+        setup={setup}
+        initialActions={[{ type: 'score-point' as const, teamId: 'team-2' as const }]}
+        startedAt={defaultStartedAt}
+        persistence={mockPersistence}
+      />
+    )
+
+    await screen.getByTestId('undo-team-1').click()
+
+    await expect.element(screen.getByTestId('actionCount')).toHaveTextContent('1')
   })
 
   test('works without persistence (uses default)', async () => {

--- a/test/components/SetupScreen/SetupScreen.browser.test.tsx
+++ b/test/components/SetupScreen/SetupScreen.browser.test.tsx
@@ -4,12 +4,15 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import { SetupScreen } from '@/components/SetupScreen/SetupScreen'
+import { createEmptyRemoteControllerBindings, createRemoteControllerBindings } from '@/lib/input'
 
-const { mockInvalidate, mockNavigate, mockPreloadRoute } = vi.hoisted(() => ({
-  mockInvalidate: vi.fn(),
-  mockNavigate: vi.fn(),
-  mockPreloadRoute: vi.fn()
-}))
+const { mockInvalidate, mockNavigate, mockPreloadRoute, mockLoadRemoteControllerBindings } =
+  vi.hoisted(() => ({
+    mockInvalidate: vi.fn(),
+    mockNavigate: vi.fn(),
+    mockPreloadRoute: vi.fn(),
+    mockLoadRemoteControllerBindings: vi.fn()
+  }))
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
@@ -24,9 +27,19 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
   }
 })
 
-describe('SetupScreen countdown timer controls', () => {
+vi.mock('@/lib/input', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/input')>()
+
+  return {
+    ...actual,
+    loadRemoteControllerBindings: mockLoadRemoteControllerBindings
+  }
+})
+
+describe('SetupScreen', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockLoadRemoteControllerBindings.mockResolvedValue(createEmptyRemoteControllerBindings())
   })
 
   afterEach(async () => {
@@ -55,9 +68,6 @@ describe('SetupScreen countdown timer controls', () => {
     const oneHourOption = screen.getByRole('radio', { name: '1:00 h' })
     const twoHourOption = screen.getByRole('radio', { name: '2:00 h' })
 
-    // Use dispatchEvent instead of Playwright's click() because the Switch element
-    // has no CSS loaded in the test environment (zero bounding box). This is equivalent
-    // to the original DOM .click() approach that bypassed Playwright's checks.
     countdownToggle.element().dispatchEvent(new MouseEvent('click', { bubbles: true }))
 
     await expect.element(countdownToggle).toHaveAttribute('aria-checked', 'true')
@@ -133,5 +143,47 @@ describe('SetupScreen countdown timer controls', () => {
     await expect.element(team2ServerButton).toBeEnabled()
     await expect.element(team2ServerButton).toHaveAttribute('aria-pressed', 'true')
     await expect.element(team1ServerButton).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  test('places the remote configuration button below the first server controls in the left column', async () => {
+    const screen = await render(<SetupScreen />)
+
+    const button = screen.getByRole('button', { name: /remote configuration/i })
+    const firstServerSection = screen.getByTestId('first-server-section')
+
+    expect(firstServerSection.element().parentElement).toBe(button.element().parentElement)
+    expect(
+      firstServerSection.element().compareDocumentPosition(button.element()) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  test('opens the remote configuration modal and loads empty bindings when nothing is saved', async () => {
+    const screen = await render(<SetupScreen />)
+
+    await screen.getByRole('button', { name: /remote configuration/i }).click()
+
+    await expect.element(screen.getByTestId('remote-configuration-modal')).toBeVisible()
+    expect(mockLoadRemoteControllerBindings).toHaveBeenCalledTimes(1)
+    await expect
+      .element(screen.getByTestId('remote-binding-add-team-1'))
+      .toHaveTextContent('Not set')
+
+    await screen.getByRole('button', { name: /cancel/i }).click()
+  })
+
+  test('opens the remote configuration modal and loads saved bindings', async () => {
+    mockLoadRemoteControllerBindings.mockResolvedValue(createRemoteControllerBindings())
+    const screen = await render(<SetupScreen />)
+
+    await screen.getByRole('button', { name: /remote configuration/i }).click()
+
+    await expect.element(screen.getByTestId('remote-configuration-modal')).toBeVisible()
+    expect(mockLoadRemoteControllerBindings).toHaveBeenCalledTimes(1)
+    await expect
+      .element(screen.getByTestId('remote-binding-add-team-1'))
+      .toHaveTextContent('← Left')
+
+    await screen.getByRole('button', { name: /cancel/i }).click()
   })
 })

--- a/test/components/SetupScreen/SetupScreen.browser.test.tsx
+++ b/test/components/SetupScreen/SetupScreen.browser.test.tsx
@@ -32,7 +32,7 @@ vi.mock('@/lib/input', async (importOriginal) => {
 
   return {
     ...actual,
-    loadRemoteControllerBindings: mockLoadRemoteControllerBindings
+    loadRemoteControllerBindingsWithFallback: mockLoadRemoteControllerBindings
   }
 })
 

--- a/test/current-match/indexed-db.browser.test.ts
+++ b/test/current-match/indexed-db.browser.test.ts
@@ -8,6 +8,7 @@ import {
   type CurrentMatchPersistence
 } from '@/lib/current-match'
 import { createLocaleStorage, type SupportedLocale } from '@/lib/i18n'
+import { createRemoteControllerBindings, createRemoteControllerStorage } from '@/lib/input'
 import { createSpeechStorage, type SpeechPreferences } from '@/lib/speech'
 
 import { createTestSetup, scorePoints, winQuickGame } from '../core/match/test-helpers'
@@ -68,7 +69,14 @@ describe('current match IndexedDB persistence', () => {
 
   test('shares the same IndexedDB bootstrap across persistence modules', async () => {
     const localeStorage = createLocaleStorage({ databaseName })
+    const remoteControllerStorage = createRemoteControllerStorage({ databaseName })
     const speechStorage = createSpeechStorage({ databaseName })
+    const remoteBindings = createRemoteControllerBindings({
+      'add-team-1': 'q',
+      'revert-team-1': 'z',
+      'add-team-2': 'w',
+      'revert-team-2': 'x'
+    })
     const speechPreferences: SpeechPreferences = {
       muted: false,
       verbosity: 'standard',
@@ -87,9 +95,13 @@ describe('current match IndexedDB persistence', () => {
       startedAt: Date.now()
     })
 
+    await remoteControllerStorage.saveRemoteControllerBindings(remoteBindings)
     await speechStorage.saveSpeechPreferences(speechPreferences)
 
     await expect(localeStorage.loadLocalePreference()).resolves.toBe('es')
+    await expect(remoteControllerStorage.loadRemoteControllerBindings()).resolves.toEqual(
+      remoteBindings
+    )
     await expect(speechStorage.loadSpeechPreferences()).resolves.toEqual(speechPreferences)
     await expect(persistence.loadCurrentMatch()).resolves.toEqual({
       status: 'ok',

--- a/test/current-match/session.test.ts
+++ b/test/current-match/session.test.ts
@@ -5,6 +5,7 @@ import {
   createCurrentMatchSession,
   createCurrentMatchSessionSnapshot,
   currentMatchSchemaVersion,
+  undoLastScoringActionForTeam,
   type CurrentMatchPersistence
 } from '@/lib/current-match'
 
@@ -107,6 +108,51 @@ describe('current match session', () => {
     expect(saveCurrentMatchMock).not.toHaveBeenCalled()
     expect(snapshot).toEqual(
       createCurrentMatchSessionSnapshot({ setup, actions: [], startedAt: testStartedAt })
+    )
+  })
+
+  test('team-specific undo removes the latest score for the selected team and replays from scratch', async () => {
+    const setup = createTestSetup()
+    const actions = scorePoints('team-1', 'team-2', 'team-1')
+    const { persistence, saveCurrentMatchMock } = createPersistenceStub()
+    const session = createCurrentMatchSession({
+      matchId: testMatchId,
+      setup,
+      actions,
+      startedAt: testStartedAt,
+      persistence
+    })
+
+    const snapshot = await session.undoScoreActionForTeam('team-1')
+    const nextActions = undoLastScoringActionForTeam(actions, 'team-1')
+
+    expect(saveCurrentMatchMock).toHaveBeenCalledWith({
+      matchId: testMatchId,
+      setup,
+      actions: nextActions,
+      startedAt: testStartedAt
+    })
+    expect(snapshot.actions).toEqual(nextActions)
+    expect(snapshot.projection).toEqual(projectMatch(setup, nextActions))
+  })
+
+  test('team-specific undo returns the existing snapshot when the selected team has no actions', async () => {
+    const setup = createTestSetup()
+    const actions = scorePoints('team-2')
+    const { persistence, saveCurrentMatchMock } = createPersistenceStub()
+    const session = createCurrentMatchSession({
+      matchId: testMatchId,
+      setup,
+      actions,
+      startedAt: testStartedAt,
+      persistence
+    })
+
+    const snapshot = await session.undoScoreActionForTeam('team-1')
+
+    expect(saveCurrentMatchMock).not.toHaveBeenCalled()
+    expect(snapshot).toEqual(
+      createCurrentMatchSessionSnapshot({ setup, actions, startedAt: testStartedAt })
     )
   })
 

--- a/test/input/keyboard-aliases.test.ts
+++ b/test/input/keyboard-aliases.test.ts
@@ -1,130 +1,100 @@
 import { describe, expect, test } from 'vitest'
 
-import { getActionFromKey, type KeyboardAction } from '@/lib/input'
+import {
+  assignRemoteControllerBinding,
+  createRemoteControllerBindings,
+  getActionFromKey,
+  getKeyboardBindingDisplayLabel,
+  type KeyboardAction
+} from '@/lib/input'
 
 describe('keyboard-aliases', () => {
-  describe('team-1 aliases', () => {
-    const team1Keys = ['ArrowLeft', 'a', '1', 'Home', 'PageUp']
-
-    test.each(team1Keys)('maps "%s" to score-team-1', (key) => {
-      expect(getActionFromKey(key)).toBe('score-team-1')
-    })
+  test.each(['ArrowLeft', 'a', 'A', '1', 'Home', 'PageUp'])('maps %s to add-team-1', (key) => {
+    expect(getActionFromKey(key)).toBe('add-team-1')
   })
 
-  describe('team-2 aliases', () => {
-    const team2Keys = ['ArrowRight', 'd', '2', 'End', 'PageDown']
-
-    test.each(team2Keys)('maps "%s" to score-team-2', (key) => {
-      expect(getActionFromKey(key)).toBe('score-team-2')
-    })
+  test.each(['ArrowRight', 'd', 'D', '2', 'End', 'PageDown'])('maps %s to add-team-2', (key) => {
+    expect(getActionFromKey(key)).toBe('add-team-2')
   })
 
-  describe('undo aliases', () => {
-    const undoKeys = ['ArrowUp', 'Backspace', 'u', 'Delete', 'Escape', 'r']
-
-    test.each(undoKeys)('maps "%s" to undo', (key) => {
+  test.each(['ArrowUp', 'Backspace', 'u', 'U', 'Delete', 'Escape', 'r', 'R'])(
+    'maps %s to undo',
+    (key) => {
       expect(getActionFromKey(key)).toBe('undo')
+    }
+  )
+
+  test('prefers custom bindings before legacy defaults', () => {
+    const bindings = createRemoteControllerBindings({
+      'add-team-1': 'ArrowRight',
+      'add-team-2': 'ArrowLeft',
+      'revert-team-1': 'z',
+      'revert-team-2': 'x'
     })
+
+    expect(getActionFromKey('ArrowRight', bindings)).toBe('add-team-1')
+    expect(getActionFromKey('ArrowLeft', bindings)).toBe('add-team-2')
+    expect(getActionFromKey('z', bindings)).toBe('revert-team-1')
+    expect(getActionFromKey('x', bindings)).toBe('revert-team-2')
   })
 
-  describe('case insensitivity', () => {
-    test('maps "A" (uppercase) to score-team-1', () => {
-      expect(getActionFromKey('A')).toBe('score-team-1')
+  test('falls back to legacy defaults when a custom binding is not configured', () => {
+    const bindings = createRemoteControllerBindings({
+      'revert-team-1': null,
+      'revert-team-2': null
     })
 
-    test('maps "D" (uppercase) to score-team-2', () => {
-      expect(getActionFromKey('D')).toBe('score-team-2')
-    })
-
-    test('maps "U" (uppercase) to undo', () => {
-      expect(getActionFromKey('U')).toBe('undo')
-    })
-
-    test('maps "R" (uppercase) to undo', () => {
-      expect(getActionFromKey('R')).toBe('undo')
-    })
+    expect(getActionFromKey('PageUp', bindings)).toBe('add-team-1')
+    expect(getActionFromKey('Escape', bindings)).toBe('undo')
   })
 
-  describe('unknown keys', () => {
-    const unknownKeys = [
-      'b',
-      'c',
-      'e',
-      'f',
-      'g',
-      'h',
-      'i',
-      'j',
-      'k',
-      'l',
-      'm',
-      'n',
-      'o',
-      'p',
-      'q',
-      's',
-      't',
-      'v',
-      'w',
-      'x',
-      'y',
-      'z',
-      '0',
-      '3',
-      '4',
-      '5',
-      '6',
-      '7',
-      '8',
-      '9',
-      'ArrowDown',
-      'Enter',
-      'Space',
-      'Tab',
-      'Shift',
-      'Control',
-      'Alt',
-      'Meta',
-      'CapsLock',
-      'F1',
-      'F12',
-      ''
+  test.each(['b', 'ArrowDown', 'Enter', 'Tab', 'Shift', '!', ''])(
+    'maps %s to unknown when it has no binding',
+    (key) => {
+      expect(getActionFromKey(key)).toBe('unknown')
+    }
+  )
+
+  test('returns the expected keyboard display labels', () => {
+    expect(getKeyboardBindingDisplayLabel('ArrowLeft')).toBe('← Left')
+    expect(getKeyboardBindingDisplayLabel('Escape')).toBe('Esc')
+    expect(getKeyboardBindingDisplayLabel('a')).toBe('A')
+    expect(getKeyboardBindingDisplayLabel(' ')).toBe('Space')
+    expect(getKeyboardBindingDisplayLabel(null)).toBe('')
+  })
+
+  test('replaces duplicate custom bindings when a key is reassigned', () => {
+    const bindings = createRemoteControllerBindings()
+    const updatedBindings = assignRemoteControllerBinding(bindings, 'add-team-2', 'ArrowLeft')
+
+    expect(updatedBindings['add-team-1']).toBeNull()
+    expect(updatedBindings['add-team-2']).toBe('ArrowLeft')
+  })
+
+  test('treats duplicate custom bindings as case insensitive', () => {
+    const bindings = createRemoteControllerBindings({
+      'add-team-1': 'a',
+      'revert-team-1': 'z',
+      'add-team-2': 'w',
+      'revert-team-2': 'x'
+    })
+
+    const updatedBindings = assignRemoteControllerBinding(bindings, 'add-team-2', 'A')
+
+    expect(updatedBindings['add-team-1']).toBeNull()
+    expect(updatedBindings['add-team-2']).toBe('A')
+  })
+
+  test('returns a valid keyboard action type', () => {
+    const validActions: KeyboardAction[] = [
+      'add-team-1',
+      'revert-team-1',
+      'add-team-2',
+      'revert-team-2',
+      'undo',
+      'unknown'
     ]
 
-    test.each(unknownKeys)('maps "%s" to unknown', (key) => {
-      expect(getActionFromKey(key)).toBe('unknown')
-    })
-
-    test('returns unknown for empty string', () => {
-      expect(getActionFromKey('')).toBe('unknown')
-    })
-
-    test('returns unknown for special characters', () => {
-      expect(getActionFromKey('!')).toBe('unknown')
-      expect(getActionFromKey('@')).toBe('unknown')
-      expect(getActionFromKey('#')).toBe('unknown')
-    })
-  })
-
-  describe('return type', () => {
-    test('returns valid KeyboardAction type for all known keys', () => {
-      const validActions: KeyboardAction[] = ['score-team-1', 'score-team-2', 'undo', 'unknown']
-      const result = getActionFromKey('a')
-
-      expect(validActions).toContain(result)
-    })
-  })
-
-  describe('edge cases', () => {
-    test('handles keys with whitespace', () => {
-      expect(getActionFromKey(' a ')).toBe('unknown')
-      expect(getActionFromKey('\ta')).toBe('unknown')
-    })
-
-    test('handles numeric string keys', () => {
-      expect(getActionFromKey('1')).toBe('score-team-1')
-      expect(getActionFromKey('2')).toBe('score-team-2')
-      expect(getActionFromKey('3')).toBe('unknown')
-    })
+    expect(validActions).toContain(getActionFromKey('a'))
   })
 })

--- a/test/input/regression.test.ts
+++ b/test/input/regression.test.ts
@@ -3,31 +3,26 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { projectMatch, type MatchTeamId } from '@/core/match'
 import { currentMatchSchemaVersion } from '@/lib/current-match/persistence'
 import { createCurrentMatchSession, type CurrentMatchPersistence } from '@/lib/current-match'
-import { getActionFromKey, createDebounce } from '@/lib/input'
+import { createDebounce, createRemoteControllerBindings, getActionFromKey } from '@/lib/input'
 
-import { createTestSetup, scorePoints, winQuickGame, winQuickSet } from '../core/match/test-helpers'
+import { createTestSetup, scorePoints } from '../core/match/test-helpers'
 
 describe('input regression', () => {
   const testMatchId = 'test-match'
   const testStartedAt = Date.now()
   let persistence: CurrentMatchPersistence
-  // Using Mock type for vitest mock to allow .mock.calls access
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let saveCurrentMatchMock: any
 
   beforeEach(() => {
-    saveCurrentMatchMock = vi
-      .fn<CurrentMatchPersistence['saveCurrentMatch']>()
-      .mockImplementation(async ({ matchId = testMatchId, setup, actions, startedAt }) => ({
-        schemaVersion: currentMatchSchemaVersion,
-        matchId,
-        setup,
-        actions,
-        startedAt: startedAt ?? testStartedAt
-      }))
-
     persistence = {
-      saveCurrentMatch: saveCurrentMatchMock,
+      saveCurrentMatch: vi
+        .fn<CurrentMatchPersistence['saveCurrentMatch']>()
+        .mockImplementation(async ({ matchId = testMatchId, setup, actions, startedAt }) => ({
+          schemaVersion: currentMatchSchemaVersion,
+          matchId,
+          setup,
+          actions,
+          startedAt: startedAt ?? testStartedAt
+        })),
       loadCurrentMatch: vi.fn(),
       clearCurrentMatch: vi.fn(async () => undefined)
     }
@@ -37,380 +32,54 @@ describe('input regression', () => {
     vi.restoreAllMocks()
   })
 
-  describe('input sequence produces same result as direct domain call', () => {
-    test('single team-1 score via keyboard alias matches direct call', async () => {
-      const setup = createTestSetup()
+  test('session scoring still matches the direct domain projection', async () => {
+    const setup = createTestSetup()
+    const scoreSequence: MatchTeamId[] = ['team-1', 'team-1', 'team-2', 'team-2', 'team-1']
 
-      // Via session (input path)
-      const session = createCurrentMatchSession({
-        matchId: testMatchId,
-        setup,
-        actions: [],
-        startedAt: testStartedAt,
-        persistence
-      })
-      await session.scorePoint('team-1')
-      const sessionSnapshot = session.getSnapshot()
-
-      // Direct domain call
-      const directProjection = projectMatch(setup, scorePoints('team-1'))
-
-      expect(sessionSnapshot.projection).toEqual(directProjection)
-      expect(sessionSnapshot.actions).toEqual(scorePoints('team-1'))
+    const session = createCurrentMatchSession({
+      matchId: testMatchId,
+      setup,
+      actions: [],
+      startedAt: testStartedAt,
+      persistence
     })
 
-    test('single team-2 score via keyboard alias matches direct call', async () => {
-      const setup = createTestSetup()
+    for (const teamId of scoreSequence) {
+      await session.scorePoint(teamId) // eslint-disable-line no-await-in-loop
+    }
 
-      const session = createCurrentMatchSession({
-        matchId: testMatchId,
-        setup,
-        actions: [],
-        startedAt: testStartedAt,
-        persistence
-      })
-      await session.scorePoint('team-2')
-      const sessionSnapshot = session.getSnapshot()
-
-      const directProjection = projectMatch(setup, scorePoints('team-2'))
-
-      expect(sessionSnapshot.projection).toEqual(directProjection)
-    })
-
-    test('multiple scores in sequence match direct domain projection', async () => {
-      const setup = createTestSetup()
-      const scoreSequence: MatchTeamId[] = [
-        'team-1',
-        'team-1',
-        'team-2',
-        'team-1',
-        'team-2',
-        'team-2'
-      ]
-
-      const session = createCurrentMatchSession({
-        matchId: testMatchId,
-        setup,
-        actions: [],
-        startedAt: testStartedAt,
-        persistence
-      })
-
-      for (const teamId of scoreSequence) {
-        await session.scorePoint(teamId) // eslint-disable-line no-await-in-loop
-      }
-      const sessionSnapshot = session.getSnapshot()
-
-      const directActions = scorePoints(...scoreSequence)
-      const directProjection = projectMatch(setup, directActions)
-
-      expect(sessionSnapshot.projection).toEqual(directProjection)
-      expect(sessionSnapshot.actions).toEqual(directActions)
-    })
-
-    test('undo after scores restores correct state', async () => {
-      const setup = createTestSetup()
-
-      const session = createCurrentMatchSession({
-        matchId: testMatchId,
-        setup,
-        actions: [],
-        startedAt: testStartedAt,
-        persistence
-      })
-
-      await session.scorePoint('team-1')
-      await session.scorePoint('team-2')
-      await session.scorePoint('team-1')
-      await session.undoScoreAction()
-
-      const sessionSnapshot = session.getSnapshot()
-
-      // Expected state: team-1, team-2 (last team-1 undone)
-      const expectedActions = scorePoints('team-1', 'team-2')
-      const expectedProjection = projectMatch(setup, expectedActions)
-
-      expect(sessionSnapshot.projection).toEqual(expectedProjection)
-      expect(sessionSnapshot.actions).toEqual(expectedActions)
-    })
-
-    test('multiple undos restore correct state', async () => {
-      const setup = createTestSetup()
-
-      const session = createCurrentMatchSession({
-        matchId: testMatchId,
-        setup,
-        actions: [],
-        startedAt: testStartedAt,
-        persistence
-      })
-
-      await session.scorePoint('team-1')
-      await session.scorePoint('team-2')
-      await session.scorePoint('team-1')
-      await session.scorePoint('team-2')
-      await session.undoScoreAction()
-      await session.undoScoreAction()
-
-      const sessionSnapshot = session.getSnapshot()
-
-      const expectedActions = scorePoints('team-1', 'team-2')
-      const expectedProjection = projectMatch(setup, expectedActions)
-
-      expect(sessionSnapshot.projection).toEqual(expectedProjection)
-    })
-
-    test('score after undo produces correct final state', async () => {
-      const setup = createTestSetup()
-
-      const session = createCurrentMatchSession({
-        matchId: testMatchId,
-        setup,
-        actions: [],
-        startedAt: testStartedAt,
-        persistence
-      })
-
-      await session.scorePoint('team-1')
-      await session.scorePoint('team-2')
-      await session.undoScoreAction()
-      await session.scorePoint('team-1')
-
-      const sessionSnapshot = session.getSnapshot()
-
-      // Expected: team-1 (original), then team-1 (new) after undo of team-2
-      const expectedActions = scorePoints('team-1', 'team-1')
-      const expectedProjection = projectMatch(setup, expectedActions)
-
-      expect(sessionSnapshot.projection).toEqual(expectedProjection)
-    })
+    expect(session.getSnapshot().projection).toEqual(
+      projectMatch(setup, scorePoints(...scoreSequence))
+    )
   })
 
-  describe('keyboard alias mapping consistency', () => {
-    test('all team-1 aliases produce same result', () => {
-      const team1Keys = ['ArrowLeft', 'a', 'A', '1', 'Home', 'PageUp']
-
-      const actions = team1Keys.map((key) => getActionFromKey(key))
-
-      expect(actions.every((action) => action === 'score-team-1')).toBe(true)
+  test('custom remote bindings resolve before the legacy shortcuts', () => {
+    const bindings = createRemoteControllerBindings({
+      'add-team-1': 'ArrowRight',
+      'add-team-2': 'ArrowLeft',
+      'revert-team-1': 'z',
+      'revert-team-2': 'x'
     })
 
-    test('all team-2 aliases produce same result', () => {
-      const team2Keys = ['ArrowRight', 'd', 'D', '2', 'End', 'PageDown']
-
-      const actions = team2Keys.map((key) => getActionFromKey(key))
-
-      expect(actions.every((action) => action === 'score-team-2')).toBe(true)
-    })
-
-    test('all undo aliases produce same result', () => {
-      const undoKeys = ['ArrowUp', 'Backspace', 'u', 'U', 'Delete', 'Escape', 'r', 'R']
-
-      const actions = undoKeys.map((key) => getActionFromKey(key))
-
-      expect(actions.every((action) => action === 'undo')).toBe(true)
-    })
+    expect(getActionFromKey('ArrowRight', bindings)).toBe('add-team-1')
+    expect(getActionFromKey('ArrowLeft', bindings)).toBe('add-team-2')
+    expect(getActionFromKey('z', bindings)).toBe('revert-team-1')
+    expect(getActionFromKey('x', bindings)).toBe('revert-team-2')
+    expect(getActionFromKey('Escape', bindings)).toBe('undo')
   })
 
-  describe('debounce does not affect final outcome', () => {
-    beforeEach(() => {
-      vi.useFakeTimers()
-    })
+  test('debounce utility still blocks rapid duplicate triggers', () => {
+    vi.useFakeTimers()
 
-    afterEach(() => {
-      vi.useRealTimers()
-    })
+    const debounce = createDebounce({ delay: 300 })
 
-    test('debounced input sequence produces same final state', async () => {
-      const setup = createTestSetup()
-      const debounce = createDebounce({ delay: 300 })
+    expect(debounce.isReady()).toBe(true)
+    debounce.trigger()
+    expect(debounce.isReady()).toBe(false)
 
-      const session = createCurrentMatchSession({
-        matchId: testMatchId,
-        setup,
-        actions: [],
-        startedAt: testStartedAt,
-        persistence
-      })
+    vi.advanceTimersByTime(300)
+    expect(debounce.isReady()).toBe(true)
 
-      // Simulate debounced input sequence
-      const inputs: MatchTeamId[] = ['team-1', 'team-2', 'team-1']
-
-      for (const teamId of inputs) {
-        if (debounce.isReady()) {
-          debounce.trigger()
-          await session.scorePoint(teamId) // eslint-disable-line no-await-in-loop
-        }
-        // Advance time to allow next input
-        vi.advanceTimersByTime(300)
-      }
-
-      const sessionSnapshot = session.getSnapshot()
-
-      // All inputs should have been processed
-      const expectedActions = scorePoints(...inputs)
-      const expectedProjection = projectMatch(setup, expectedActions)
-
-      expect(sessionSnapshot.projection).toEqual(expectedProjection)
-    })
-
-    test('rapid debounced inputs only register after delay', async () => {
-      const setup = createTestSetup()
-      const debounce = createDebounce({ delay: 300 })
-
-      const session = createCurrentMatchSession({
-        matchId: testMatchId,
-        setup,
-        actions: [],
-        startedAt: testStartedAt,
-        persistence
-      })
-
-      // First input should succeed
-      if (debounce.isReady()) {
-        debounce.trigger()
-        await session.scorePoint('team-1')
-      }
-
-      // Rapid second input should be blocked
-      let secondScored = false
-      if (debounce.isReady()) {
-        debounce.trigger()
-        await session.scorePoint('team-2')
-        secondScored = true
-      }
-
-      expect(secondScored).toBe(false)
-
-      // After delay, third input should succeed
-      vi.advanceTimersByTime(300)
-      let thirdScored = false
-      if (debounce.isReady()) {
-        debounce.trigger()
-        await session.scorePoint('team-2')
-        thirdScored = true
-      }
-
-      expect(thirdScored).toBe(true)
-
-      const sessionSnapshot = session.getSnapshot()
-      const expectedActions = scorePoints('team-1', 'team-2')
-      const expectedProjection = projectMatch(setup, expectedActions)
-
-      expect(sessionSnapshot.projection).toEqual(expectedProjection)
-    })
-  })
-
-  describe('full game simulation via input', () => {
-    test('complete game via keyboard produces correct winner', async () => {
-      const setup = createTestSetup({ format: 'best-of-1' })
-
-      const session = createCurrentMatchSession({
-        matchId: testMatchId,
-        setup,
-        actions: [],
-        startedAt: testStartedAt,
-        persistence
-      })
-
-      // Team 1 wins 4 points to win a game
-      for (let i = 0; i < 4; i++) {
-        await session.scorePoint('team-1') // eslint-disable-line no-await-in-loop
-      }
-
-      const sessionSnapshot = session.getSnapshot()
-
-      const expectedActions = winQuickGame('team-1')
-      const expectedProjection = projectMatch(setup, expectedActions)
-
-      expect(sessionSnapshot.projection).toEqual(expectedProjection)
-      // Game was won by team-1 (4-0), verify games count
-      const activeSet = sessionSnapshot.projection.state.sets[0]!
-      expect(activeSet.games).toEqual({
-        'team-1': 1,
-        'team-2': 0
-      })
-    })
-
-    test('complete set via keyboard produces correct winner', async () => {
-      const setup = createTestSetup({ format: 'best-of-1' })
-
-      const session = createCurrentMatchSession({
-        matchId: testMatchId,
-        setup,
-        actions: [],
-        startedAt: testStartedAt,
-        persistence
-      })
-
-      // Team 1 wins 6 games to win a set
-      const winSetActions = winQuickSet('team-1')
-      for (const _ of winSetActions) {
-        await session.scorePoint('team-1') // eslint-disable-line no-await-in-loop
-      }
-
-      const sessionSnapshot = session.getSnapshot()
-
-      const expectedProjection = projectMatch(setup, winSetActions)
-
-      expect(sessionSnapshot.projection).toEqual(expectedProjection)
-      expect(sessionSnapshot.projection.derived.status).toBe('completed')
-      expect(sessionSnapshot.projection.derived.winner?.teamId).toBe('team-1')
-    })
-
-    test('match state is consistent after complex sequence', async () => {
-      const setup = createTestSetup()
-
-      const session = createCurrentMatchSession({
-        matchId: testMatchId,
-        setup,
-        actions: [],
-        startedAt: testStartedAt,
-        persistence
-      })
-
-      // Complex sequence with scoring and undoing
-      await session.scorePoint('team-1')
-      await session.scorePoint('team-1')
-      await session.scorePoint('team-2')
-      await session.scorePoint('team-1')
-      await session.scorePoint('team-2')
-      await session.undoScoreAction()
-      await session.scorePoint('team-1')
-      await session.undoScoreAction()
-      await session.scorePoint('team-1')
-
-      const sessionSnapshot = session.getSnapshot()
-
-      // Final state: team-1, team-1, team-2, team-1, team-1 (after undos and scores)
-      const expectedActions = scorePoints('team-1', 'team-1', 'team-2', 'team-1', 'team-1')
-      const expectedProjection = projectMatch(setup, expectedActions)
-
-      expect(sessionSnapshot.projection).toEqual(expectedProjection)
-      expect(sessionSnapshot.actions).toEqual(expectedActions)
-    })
-  })
-
-  describe('persistence consistency', () => {
-    test('session persistence matches direct persistence call', async () => {
-      const setup = createTestSetup()
-
-      const session = createCurrentMatchSession({
-        matchId: testMatchId,
-        setup,
-        actions: [],
-        startedAt: testStartedAt,
-        persistence
-      })
-
-      await session.scorePoint('team-1')
-      await session.scorePoint('team-2')
-
-      expect(saveCurrentMatchMock).toHaveBeenCalledTimes(2)
-
-      // Verify the last call matches expected state
-      const lastCall = saveCurrentMatchMock.mock.calls[1][0]
-      expect(lastCall.actions).toEqual(scorePoints('team-1', 'team-2'))
-    })
+    vi.useRealTimers()
   })
 })

--- a/test/input/remote-controller-storage.test.ts
+++ b/test/input/remote-controller-storage.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  createRemoteControllerBindings,
+  createRemoteControllerStorage,
+  type RemoteControllerBindings
+} from '@/lib/input'
+import { sharedIndexedDbObjectStoreNames } from '@/lib/persistence/indexed-db'
+
+describe('remote-controller-storage', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  test('saves and loads remote controller bindings', async () => {
+    const fakeIndexedDb = createFakeIndexedDb()
+    vi.stubGlobal('indexedDB', fakeIndexedDb.factory)
+
+    const storage = createRemoteControllerStorage({ databaseName: 'test-remote-db' })
+    const bindings = createRemoteControllerBindings({
+      'add-team-1': 'q',
+      'revert-team-1': 'z',
+      'add-team-2': 'w',
+      'revert-team-2': 'x'
+    })
+
+    await storage.saveRemoteControllerBindings(bindings)
+
+    await expect(storage.loadRemoteControllerBindings()).resolves.toEqual(bindings)
+  })
+
+  test('clears remote controller bindings', async () => {
+    const fakeIndexedDb = createFakeIndexedDb()
+    vi.stubGlobal('indexedDB', fakeIndexedDb.factory)
+
+    const storage = createRemoteControllerStorage({ databaseName: 'clear-remote-db' })
+
+    await storage.saveRemoteControllerBindings(createRemoteControllerBindings())
+    await storage.clearRemoteControllerBindings()
+
+    await expect(storage.loadRemoteControllerBindings()).resolves.toBeNull()
+  })
+
+  test('returns null when the stored record is malformed', async () => {
+    const fakeIndexedDb = createFakeIndexedDb({
+      seedValue: {
+        bindings: {
+          'add-team-1': 'q',
+          'revert-team-1': 'z',
+          'add-team-2': 'w'
+        },
+        updatedAt: '2024-01-01T00:00:00.000Z'
+      }
+    })
+    vi.stubGlobal('indexedDB', fakeIndexedDb.factory)
+
+    const storage = createRemoteControllerStorage({ databaseName: 'invalid-remote-db' })
+
+    await expect(storage.loadRemoteControllerBindings()).resolves.toBeNull()
+  })
+
+  test('returns null when the stored metadata is invalid', async () => {
+    const fakeIndexedDb = createFakeIndexedDb({
+      seedValue: {
+        bindings: createRemoteControllerBindings(),
+        updatedAt: 123
+      }
+    })
+    vi.stubGlobal('indexedDB', fakeIndexedDb.factory)
+
+    const storage = createRemoteControllerStorage({ databaseName: 'invalid-remote-meta-db' })
+
+    await expect(storage.loadRemoteControllerBindings()).resolves.toBeNull()
+  })
+
+  test('registers the shared IndexedDB stores during upgrade', async () => {
+    const fakeIndexedDb = createFakeIndexedDb()
+    vi.stubGlobal('indexedDB', fakeIndexedDb.factory)
+
+    const storage = createRemoteControllerStorage({ databaseName: 'shared-remote-db' })
+
+    await expect(storage.loadRemoteControllerBindings()).resolves.toBeNull()
+    expect(fakeIndexedDb.createdObjectStores).toEqual([...sharedIndexedDbObjectStoreNames])
+  })
+
+  test('rejects when IndexedDB is unavailable', async () => {
+    vi.stubGlobal('indexedDB', undefined)
+
+    const storage = createRemoteControllerStorage({ databaseName: 'missing-indexeddb' })
+
+    await expect(storage.loadRemoteControllerBindings()).rejects.toThrowError(
+      'IndexedDB is not available in this environment.'
+    )
+  })
+})
+
+function createFakeIndexedDb(
+  options: {
+    seedValue?: unknown
+  } = {}
+) {
+  const createdObjectStores: string[] = []
+  const storage = new Map<string, unknown>()
+
+  if (typeof options.seedValue !== 'undefined') {
+    storage.set('remote-controller-bindings', options.seedValue)
+  }
+
+  const factory = {
+    open: vi.fn((_databaseName: string, _version?: number) => {
+      const request = new FakeOpenRequest<FakeDatabase>()
+      const database = new FakeDatabase(storage, createdObjectStores)
+
+      queueMicrotask(() => {
+        request.result = database
+        request.dispatchEvent(new Event('upgradeneeded'))
+        request.dispatchEvent(new Event('success'))
+      })
+
+      return request
+    })
+  }
+
+  return {
+    factory,
+    createdObjectStores
+  }
+}
+
+class FakeOpenRequest<TResult> extends EventTarget {
+  error: Error | null = null
+  result!: TResult
+}
+
+class FakeRequest<TResult> extends EventTarget {
+  error: Error | null = null
+  result!: TResult
+}
+
+class FakeDatabase {
+  private readonly storeNames = new Set<string>()
+
+  constructor(
+    private readonly storage: Map<string, unknown>,
+    private readonly createdObjectStores: string[]
+  ) {}
+
+  objectStoreNames = {
+    contains: (name: string) => this.storeNames.has(name)
+  }
+
+  createObjectStore(name: string): Record<string, never> {
+    this.storeNames.add(name)
+    this.createdObjectStores.push(name)
+
+    return {}
+  }
+
+  transaction(_name: string, _mode: string): FakeTransaction {
+    return new FakeTransaction(this.storage)
+  }
+
+  close(): void {}
+}
+
+class FakeTransaction extends EventTarget {
+  error: Error | null = null
+
+  constructor(private readonly storage: Map<string, unknown>) {
+    super()
+  }
+
+  objectStore(_name: string) {
+    return {
+      get: (key: unknown) => {
+        const request = new FakeRequest<RemoteControllerBindings | undefined>()
+
+        queueMicrotask(() => {
+          request.result = this.storage.get(String(key)) as RemoteControllerBindings | undefined
+          request.dispatchEvent(new Event('success'))
+          queueMicrotask(() => {
+            this.dispatchEvent(new Event('complete'))
+          })
+        })
+
+        return request
+      },
+      put: (value: unknown, key: unknown) => {
+        this.storage.set(String(key), value)
+        queueMicrotask(() => {
+          this.dispatchEvent(new Event('complete'))
+        })
+      },
+      delete: (key: unknown) => {
+        this.storage.delete(String(key))
+        queueMicrotask(() => {
+          this.dispatchEvent(new Event('complete'))
+        })
+      }
+    }
+  }
+}

--- a/test/input/use-input-handler.browser.test.tsx
+++ b/test/input/use-input-handler.browser.test.tsx
@@ -202,7 +202,7 @@ describe('use-input-handler browser', () => {
 
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z' }))
 
-    expect(onUndoForTeam).toHaveBeenCalledWith('team-1')
+    expect(onUndoForTeam).not.toHaveBeenCalled()
     await expect.element(screen.getByTestId('action-count')).toHaveTextContent('1')
   })
 
@@ -422,6 +422,99 @@ describe('use-input-handler browser', () => {
     await expect.element(screen.getByTestId('action-count')).toHaveTextContent('0')
   })
 
+  test('cancels a pending buffered add when the handler becomes disabled', async () => {
+    vi.useFakeTimers()
+
+    const onAdd = vi.fn()
+
+    function ToggleEnabledHarness() {
+      const [enabled, setEnabled] = useState(true)
+      const state = useInputHandler(
+        {
+          actions: [],
+          enabled
+        },
+        {
+          onAdd,
+          onUndo: async () => undefined,
+          onUndoForTeam: async () => undefined
+        }
+      )
+
+      return (
+        <button type="button" data-testid="disable-handler" onClick={() => setEnabled(false)}>
+          {state.wakeLockState.isActive ? 'active' : 'inactive'}
+        </button>
+      )
+    }
+
+    const screen = await render(<ToggleEnabledHarness />)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
+    await screen.getByTestId('disable-handler').click()
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect(onAdd).not.toHaveBeenCalled()
+  })
+
+  test('enabled ref guard prevents a buffered add from committing after disable', async () => {
+    vi.useFakeTimers()
+
+    const onAdd = vi.fn()
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout').mockImplementation(() => undefined)
+
+    function ToggleEnabledHarness() {
+      const [enabled, setEnabled] = useState(true)
+      const state = useInputHandler(
+        {
+          actions: [],
+          enabled
+        },
+        {
+          onAdd,
+          onUndo: async () => undefined,
+          onUndoForTeam: async () => undefined
+        }
+      )
+
+      return (
+        <button type="button" data-testid="disable-handler" onClick={() => setEnabled(false)}>
+          {state.wakeLockState.isActive ? 'active' : 'inactive'}
+        </button>
+      )
+    }
+
+    const screen = await render(<ToggleEnabledHarness />)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
+    await screen.getByTestId('disable-handler').click()
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+    expect(onAdd).not.toHaveBeenCalled()
+  })
+
+  test('double-press with no prior team action cancels the add without calling undo', async () => {
+    // When actions = [] and user double-presses team-1's add key:
+    // First press queues buffered add, second press cancels timer and calls undoForTeam,
+    // but undoForTeam bails because hasScoringAction is false.
+    // Net result: no score, no undo — both presses silently discarded.
+    vi.useFakeTimers()
+
+    const onAdd = vi.fn()
+    const onUndoForTeam = vi.fn()
+
+    await render(<InputHandlerHarness onAdd={onAdd} onUndoForTeam={onUndoForTeam} />)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
+    await vi.advanceTimersByTimeAsync(100)
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect(onAdd).not.toHaveBeenCalled()
+    expect(onUndoForTeam).not.toHaveBeenCalled()
+  })
+
   test('ignores mapped keyboard input when the handler is disabled', async () => {
     vi.useFakeTimers()
 
@@ -470,7 +563,7 @@ describe('use-input-handler browser', () => {
 
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z' }))
 
-    expect(onUndoForTeam).toHaveBeenCalledWith('team-1')
+    expect(onUndoForTeam).not.toHaveBeenCalled()
     await expect.element(screen.getByTestId('action-count')).toHaveTextContent('0')
   })
 

--- a/test/input/use-input-handler.browser.test.tsx
+++ b/test/input/use-input-handler.browser.test.tsx
@@ -1,537 +1,527 @@
+/* oxlint-disable jsx-no-new-function-as-prop, jsx-no-new-object-as-prop, jsx-no-new-array-as-prop -- test harness props are intentionally inline for readability. */
+
+import { useEffect, useState } from 'react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-/* eslint-disable react-perf/jsx-no-new-object-as-prop, react-perf/jsx-no-new-function-as-prop, @typescript-eslint/no-explicit-any */
 import { render } from 'vitest-browser-react'
-import { useEffect } from 'react'
 
-import {
-  useInputHandler,
-  type UseInputHandlerOptions,
-  type UseInputHandlerReturn,
-  type UseInputHandlerCallbacks
-} from '@/lib/input'
-import { currentMatchSchemaVersion } from '@/lib/current-match/persistence'
-import {
-  createCurrentMatchSession,
-  type CurrentMatchSession,
-  type CurrentMatchPersistence
-} from '@/lib/current-match'
+import { useInputHandler, type RemoteControllerBindings } from '@/lib/input'
+import type { MatchAction, MatchTeamId } from '@/core/match'
 
-import { createTestSetup } from '../core/match/test-helpers'
+function removeLastTeamAction(actions: MatchAction[], teamId: MatchTeamId): MatchAction[] {
+  const actionIndex = actions.findLastIndex((action) => action.teamId === teamId)
 
-const testMatchId = 'test-match'
+  if (actionIndex < 0) {
+    return actions
+  }
 
-// Helper function at module scope to avoid eslint warning about function recreation
-const createOptions = (sessionObj: CurrentMatchSession) => ({ session: sessionObj })
+  return [...actions.slice(0, actionIndex), ...actions.slice(actionIndex + 1)]
+}
 
-// Test component to render the hook output
-function InputHandlerTestComponent({
-  options,
-  callbacks,
+function InputHandlerHarness({
+  enabled = true,
+  bindings = null,
+  initialActions = [],
+  bufferedAddWindowMs = 380,
+  onAdd = vi.fn(),
+  onUndo = vi.fn(),
+  onUndoForTeam = vi.fn(),
+  onError = vi.fn(),
   onStateChange
 }: {
-  options: UseInputHandlerOptions
-  callbacks?: UseInputHandlerCallbacks
-  onStateChange?: (state: UseInputHandlerReturn) => void
+  enabled?: boolean
+  bindings?: RemoteControllerBindings | null
+  initialActions?: MatchAction[]
+  bufferedAddWindowMs?: number
+  onAdd?: (teamId: MatchTeamId) => void
+  onUndo?: () => void
+  onUndoForTeam?: (teamId: MatchTeamId) => void
+  onError?: (error: Error) => void
+  onStateChange?: (state: ReturnType<typeof useInputHandler>) => void
 }) {
-  const state = useInputHandler(options, callbacks)
+  const [actions, setActions] = useState<MatchAction[]>(initialActions)
+  const state = useInputHandler(
+    {
+      actions,
+      bindings,
+      enabled,
+      bufferedAddWindowMs
+    },
+    {
+      onAdd: async (teamId) => {
+        setActions((currentActions) => [...currentActions, { type: 'score-point', teamId }])
+        onAdd(teamId)
+      },
+      onUndo: async () => {
+        setActions((currentActions) => currentActions.slice(0, -1))
+        onUndo()
+      },
+      onUndoForTeam: async (teamId) => {
+        setActions((currentActions) => removeLastTeamAction(currentActions, teamId))
+        onUndoForTeam(teamId)
+      },
+      onError
+    }
+  )
 
   useEffect(() => {
     onStateChange?.(state)
-  }, [state, onStateChange])
+  }, [onStateChange, state])
 
   return (
     <div>
-      <span data-testid="enabled">{options.enabled !== false ? 'true' : 'false'}</span>
-      <button data-testid="team1Score" type="button" onClick={state.handlers.onTeam1Score}>
-        Team 1 Score
+      <button data-testid="touch-add-team-1" type="button" onClick={state.handlers.onTeam1Score}>
+        Add team 1
       </button>
-      <button data-testid="team2Score" type="button" onClick={state.handlers.onTeam2Score}>
-        Team 2 Score
+      <button data-testid="touch-add-team-2" type="button" onClick={state.handlers.onTeam2Score}>
+        Add team 2
       </button>
-      <button data-testid="undo" type="button" onClick={state.handlers.onUndo}>
+      <button data-testid="touch-undo" type="button" onClick={state.handlers.onUndo}>
         Undo
       </button>
-      <span data-testid="wakeLockSupported">{state.wakeLockState.isSupported.toString()}</span>
+      <span data-testid="action-count">{actions.length}</span>
+      <span data-testid="latest-team">{actions.at(-1)?.teamId ?? 'none'}</span>
     </div>
   )
 }
 
 describe('use-input-handler browser', () => {
-  let session: CurrentMatchSession
-  let mockPersistence: CurrentMatchPersistence
-
   beforeEach(() => {
-    const matchSetup = createTestSetup()
-    const testStartedAt = Date.now()
-    mockPersistence = {
-      saveCurrentMatch: vi
-        .fn<CurrentMatchPersistence['saveCurrentMatch']>()
-        .mockImplementation(async ({ matchId = testMatchId, setup, actions, startedAt }) => ({
-          schemaVersion: currentMatchSchemaVersion,
-          matchId,
-          setup,
-          actions,
-          startedAt: startedAt ?? testStartedAt
-        })),
-      loadCurrentMatch: vi.fn(),
-      clearCurrentMatch: vi.fn(async () => undefined)
-    }
-    session = createCurrentMatchSession({
-      matchId: testMatchId,
-      setup: matchSetup,
-      actions: [],
-      startedAt: testStartedAt,
-      persistence: mockPersistence
-    })
+    vi.clearAllMocks()
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
-  describe('keyboard event handling', () => {
-    test('handles ArrowLeft key for team-1 score', async () => {
-      const onScore = vi.fn()
-      // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
-      const options = createOptions(session)
-      // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
-      const callbacks = { onScore }
+  test('commits a mapped add after the buffered window', async () => {
+    vi.useFakeTimers()
 
-      await render(<InputHandlerTestComponent options={options} callbacks={callbacks} />)
+    const onAdd = vi.fn()
+    await render(<InputHandlerHarness onAdd={onAdd} />)
 
-      // Simulate keyboard event
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
 
-      // Wait for the callback to be called
-      await vi.waitFor(() => expect(onScore).toHaveBeenCalledWith('team-1'))
-    })
+    expect(onAdd).not.toHaveBeenCalled()
 
-    test('handles ArrowRight key for team-2 score', async () => {
-      const onScore = vi.fn()
-      const options = createOptions(session)
-      const callbacks = { onScore }
+    await vi.advanceTimersByTimeAsync(380)
 
-      await render(<InputHandlerTestComponent options={options} callbacks={callbacks} />)
-
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }))
-
-      await vi.waitFor(() => expect(onScore).toHaveBeenCalledWith('team-2'))
-    })
-
-    test('handles ArrowUp key for undo', async () => {
-      const onUndo = vi.fn()
-      const options = createOptions(session)
-      const callbacks = { onUndo }
-
-      await render(<InputHandlerTestComponent options={options} callbacks={callbacks} />)
-
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }))
-
-      await vi.waitFor(() => expect(onUndo).toHaveBeenCalled())
-    })
-
-    test('ignores unknown keys', async () => {
-      const onScore = vi.fn()
-      const onUndo = vi.fn()
-      const options = createOptions(session)
-      const callbacks = { onScore, onUndo }
-
-      await render(<InputHandlerTestComponent options={options} callbacks={callbacks} />)
-
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'x' }))
-
-      await vi.waitFor(() => {
-        expect(onScore).not.toHaveBeenCalled()
-        expect(onUndo).not.toHaveBeenCalled()
-      })
-    })
-
-    test('does not handle events when disabled', async () => {
-      const onScore = vi.fn()
-      const options = { session, enabled: false }
-      const callbacks = { onScore }
-
-      const screen = await render(
-        <InputHandlerTestComponent options={options} callbacks={callbacks} />
-      )
-
-      // When enabled is false, the click handler should also return early
-      await screen.getByTestId('team1Score').click()
-
-      await vi.waitFor(() => expect(onScore).not.toHaveBeenCalled())
-    })
+    expect(onAdd).toHaveBeenCalledWith('team-1')
   })
 
-  describe('touch/click handlers', () => {
-    test('onTeam1Score triggers team-1 score', async () => {
-      const onScore = vi.fn()
-      const options = createOptions(session)
-      const callbacks = { onScore }
+  test('supports custom mapped adds for team 2', async () => {
+    vi.useFakeTimers()
 
-      const screen = await render(
-        <InputHandlerTestComponent options={options} callbacks={callbacks} />
-      )
+    const onAdd = vi.fn()
+    await render(
+      <InputHandlerHarness
+        onAdd={onAdd}
+        bindings={{
+          'add-team-1': 'q',
+          'revert-team-1': 'a',
+          'add-team-2': 'w',
+          'revert-team-2': 's'
+        }}
+      />
+    )
 
-      await screen.getByTestId('team1Score').click()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'w' }))
+    await vi.advanceTimersByTimeAsync(380)
 
-      await vi.waitFor(() => expect(onScore).toHaveBeenCalledWith('team-1'))
-    })
-
-    test('onTeam2Score triggers team-2 score', async () => {
-      const onScore = vi.fn()
-      const options = createOptions(session)
-      const callbacks = { onScore }
-
-      const screen = await render(
-        <InputHandlerTestComponent options={options} callbacks={callbacks} />
-      )
-
-      await screen.getByTestId('team2Score').click()
-
-      await vi.waitFor(() => expect(onScore).toHaveBeenCalledWith('team-2'))
-    })
-
-    test('onUndo triggers undo', async () => {
-      const onUndo = vi.fn()
-      const options = createOptions(session)
-      const callbacks = { onUndo }
-
-      const screen = await render(
-        <InputHandlerTestComponent options={options} callbacks={callbacks} />
-      )
-
-      await screen.getByTestId('undo').click()
-
-      await vi.waitFor(() => expect(onUndo).toHaveBeenCalled())
-    })
-
-    test('touch handlers do not work when disabled', async () => {
-      const onScore = vi.fn()
-      const options = { session, enabled: false }
-      const callbacks = { onScore }
-
-      const screen = await render(
-        <InputHandlerTestComponent options={options} callbacks={callbacks} />
-      )
-
-      await screen.getByTestId('team1Score').click()
-
-      await vi.waitFor(() => expect(onScore).not.toHaveBeenCalled())
-    })
+    expect(onAdd).toHaveBeenCalledWith('team-2')
   })
 
-  describe('debounce prevents rapid duplicate scores', () => {
-    test('debounces rapid button clicks', async () => {
-      vi.useFakeTimers({ toFake: ['Date'] })
+  test('double pressing the same add key reverts that team instead of scoring', async () => {
+    vi.useFakeTimers()
 
-      const onScore = vi.fn()
-      const options = createOptions(session)
-      const callbacks = { onScore }
+    const onAdd = vi.fn()
+    const onUndoForTeam = vi.fn()
+    const initialActions: MatchAction[] = [{ type: 'score-point', teamId: 'team-1' }]
 
-      const screen = await render(
-        <InputHandlerTestComponent options={options} callbacks={callbacks} />
-      )
+    const screen = await render(
+      <InputHandlerHarness
+        initialActions={initialActions}
+        onAdd={onAdd}
+        onUndoForTeam={onUndoForTeam}
+      />
+    )
 
-      // First click registers and sets debounce timestamp
-      await screen.getByTestId('team1Score').click()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
+    await vi.advanceTimersByTimeAsync(150)
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
+    await vi.advanceTimersByTimeAsync(400)
 
-      // Wait for the first callback to complete
-      await vi.waitFor(() => expect(onScore).toHaveBeenCalledTimes(1))
-      expect(onScore).toHaveBeenCalledWith('team-1')
-
-      // Don't advance time - second click should be debounced
-      await screen.getByTestId('team1Score').click()
-
-      // Verify debounce blocked the second click
-      expect(onScore).toHaveBeenCalledTimes(1)
-
-      vi.useRealTimers()
-    })
-
-    test('allows score after debounce period', async () => {
-      const onScore = vi.fn()
-      const options = createOptions(session)
-      const callbacks = { onScore }
-
-      const screen = await render(
-        <InputHandlerTestComponent options={options} callbacks={callbacks} />
-      )
-
-      // First click
-      await screen.getByTestId('team1Score').click()
-
-      await vi.waitFor(() => expect(onScore).toHaveBeenCalledTimes(1))
-
-      // Wait for debounce to expire (300ms + buffer)
-      await new Promise((resolve) => setTimeout(resolve, 350))
-
-      // Second click should now register
-      await screen.getByTestId('team1Score').click()
-
-      await vi.waitFor(() => expect(onScore).toHaveBeenCalledTimes(2))
-    })
-
-    test('undo is not debounced', async () => {
-      const onUndo = vi.fn()
-      const options = createOptions(session)
-      const callbacks = { onUndo }
-
-      const screen = await render(
-        <InputHandlerTestComponent options={options} callbacks={callbacks} />
-      )
-
-      // First undo
-      await screen.getByTestId('undo').click()
-
-      await vi.waitFor(() => expect(onUndo).toHaveBeenCalledTimes(1))
-
-      // Rapid second undo should also work
-      await screen.getByTestId('undo').click()
-
-      await vi.waitFor(() => expect(onUndo).toHaveBeenCalledTimes(2))
-    })
+    expect(onAdd).not.toHaveBeenCalled()
+    expect(onUndoForTeam).toHaveBeenCalledWith('team-1')
+    await expect.element(screen.getByTestId('action-count')).toHaveTextContent('0')
   })
 
-  describe('wake lock integration', () => {
-    test('handles wake lock error when useWakeLock is enabled', async () => {
-      const onError = vi.fn()
-      const options = { session, useWakeLock: true }
-      const callbacks = { onError }
+  test('explicit revert mapping removes the last team-specific action even when another team scored later', async () => {
+    const onUndoForTeam = vi.fn()
+    const bindings: RemoteControllerBindings = {
+      'add-team-1': 'q',
+      'revert-team-1': 'z',
+      'add-team-2': 'w',
+      'revert-team-2': 'x'
+    }
 
-      // This test just verifies the component renders with wake lock enabled
-      // The actual wake lock error handling is tested in wake-lock.browser.test.tsx
-      const screen = await render(
-        <InputHandlerTestComponent options={options} callbacks={callbacks} />
-      )
+    const screen = await render(
+      <InputHandlerHarness
+        bindings={bindings}
+        initialActions={[
+          { type: 'score-point', teamId: 'team-1' },
+          { type: 'score-point', teamId: 'team-2' }
+        ]}
+        onUndoForTeam={onUndoForTeam}
+      />
+    )
 
-      await expect.element(screen.getByTestId('wakeLockSupported')).toBeVisible()
-    })
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z' }))
+
+    expect(onUndoForTeam).toHaveBeenCalledWith('team-1')
+    await expect.element(screen.getByTestId('action-count')).toHaveTextContent('1')
+    await expect.element(screen.getByTestId('latest-team')).toHaveTextContent('team-2')
   })
 
-  describe('handler invocation', () => {
-    test('onKeyDown handler respects enabled: false via state', async () => {
-      const onScore = vi.fn()
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let handlerRef: any = null
+  test('explicit revert mapping does nothing when that team has no scoring action', async () => {
+    const onUndoForTeam = vi.fn()
+    const bindings: RemoteControllerBindings = {
+      'add-team-1': 'q',
+      'revert-team-1': 'z',
+      'add-team-2': 'w',
+      'revert-team-2': 'x'
+    }
 
-      const options = { session, enabled: false }
-      const callbacks = { onScore }
+    const screen = await render(
+      <InputHandlerHarness
+        bindings={bindings}
+        initialActions={[{ type: 'score-point', teamId: 'team-2' }]}
+        onUndoForTeam={onUndoForTeam}
+      />
+    )
 
-      await render(
-        <InputHandlerTestComponent
-          options={options}
-          callbacks={callbacks}
-          onStateChange={(state) => {
-            handlerRef = state.handlers.onKeyDown
-          }}
-        />
-      )
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z' }))
 
-      // Now call the handler directly
-      if (handlerRef) {
-        handlerRef(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
-      }
-
-      await vi.waitFor(() => {
-        // onScore should NOT be called because enabled is false
-        expect(onScore).not.toHaveBeenCalled()
-      })
-    })
+    expect(onUndoForTeam).toHaveBeenCalledWith('team-1')
+    await expect.element(screen.getByTestId('action-count')).toHaveTextContent('1')
   })
 
-  describe('return value', () => {
-    test('works without callbacks provided', async () => {
-      const options = createOptions(session)
+  test('team-2 revert mapping removes the last team-2 action', async () => {
+    const onUndoForTeam = vi.fn()
 
-      const screen = await render(<InputHandlerTestComponent options={options} />)
+    const screen = await render(
+      <InputHandlerHarness
+        bindings={{
+          'add-team-1': 'q',
+          'revert-team-1': 'z',
+          'add-team-2': 'w',
+          'revert-team-2': 'x'
+        }}
+        initialActions={[
+          { type: 'score-point', teamId: 'team-2' },
+          { type: 'score-point', teamId: 'team-1' },
+          { type: 'score-point', teamId: 'team-2' }
+        ]}
+        onUndoForTeam={onUndoForTeam}
+      />
+    )
 
-      // Should render without errors even without callbacks
-      await expect.element(screen.getByTestId('team1Score')).toBeVisible()
-    })
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'x' }))
 
-    test('returns correct interface shape', async () => {
-      const options = createOptions(session)
-      const screen = await render(<InputHandlerTestComponent options={options} />)
-
-      // Check that the component renders with expected elements
-      await expect.element(screen.getByTestId('team1Score')).toBeVisible()
-      await expect.element(screen.getByTestId('team2Score')).toBeVisible()
-      await expect.element(screen.getByTestId('undo')).toBeVisible()
-      await expect.element(screen.getByTestId('wakeLockSupported')).toBeVisible()
-    })
+    expect(onUndoForTeam).toHaveBeenCalledWith('team-2')
+    await expect.element(screen.getByTestId('action-count')).toHaveTextContent('2')
+    await expect.element(screen.getByTestId('latest-team')).toHaveTextContent('team-1')
   })
 
-  describe('error handling', () => {
-    test('calls onError callback when score fails', async () => {
-      const onError = vi.fn()
+  test('legacy undo keys still work', async () => {
+    const onUndo = vi.fn()
+    const screen = await render(
+      <InputHandlerHarness
+        initialActions={[{ type: 'score-point', teamId: 'team-1' }]}
+        onUndo={onUndo}
+      />
+    )
 
-      // Create a session that throws on score - use a proper mock that implements the interface
-      const failingSession = {
-        getSnapshot: () => session.getSnapshot(),
-        scorePoint: vi.fn().mockRejectedValue(new Error('Score failed')),
-        undoScoreAction: vi.fn().mockResolvedValue(session.getSnapshot()),
-        continuePlaying: vi.fn().mockResolvedValue(session.getSnapshot())
-      }
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion
-      const options = { session: failingSession as any }
-      const callbacks = { onError }
-
-      const screen = await render(
-        <InputHandlerTestComponent options={options} callbacks={callbacks} />
-      )
-
-      await screen.getByTestId('team1Score').click()
-
-      await vi.waitFor(() => {
-        expect(onError).toHaveBeenCalledWith(expect.any(Error))
-        expect(onError.mock.calls[0]![0].message).toBe('Score failed')
-      })
-    })
-
-    test('calls onError callback when undo fails', async () => {
-      const onError = vi.fn()
-
-      const failingSession = {
-        getSnapshot: () => session.getSnapshot(),
-        scorePoint: vi.fn().mockResolvedValue(session.getSnapshot()),
-        undoScoreAction: vi.fn().mockRejectedValue(new Error('Undo failed')),
-        continuePlaying: vi.fn().mockResolvedValue(session.getSnapshot())
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion
-      const options = { session: failingSession as any }
-      const callbacks = { onError }
-
-      const screen = await render(
-        <InputHandlerTestComponent options={options} callbacks={callbacks} />
-      )
-
-      await screen.getByTestId('undo').click()
-
-      await vi.waitFor(() => {
-        expect(onError).toHaveBeenCalledWith(expect.any(Error))
-        expect(onError.mock.calls[0]![0].message).toBe('Undo failed')
-      })
-    })
+    expect(onUndo).toHaveBeenCalledTimes(1)
+    await expect.element(screen.getByTestId('action-count')).toHaveTextContent('0')
   })
 
-  describe('debounce edge cases', () => {
-    test('does not trigger score when debounce is not ready', async () => {
-      const onScore = vi.fn()
-      const options = createOptions(session)
-      const callbacks = { onScore }
+  test('mapped keys call preventDefault', async () => {
+    let handler: ((event: KeyboardEvent) => void) | null = null
 
-      const screen = await render(
-        <InputHandlerTestComponent options={options} callbacks={callbacks} />
-      )
+    await render(
+      <InputHandlerHarness
+        onStateChange={(state) => {
+          handler = state.handlers.onKeyDown
+        }}
+      />
+    )
 
-      // First click - should work
-      await screen.getByTestId('team1Score').click()
-      await vi.waitFor(() => expect(onScore).toHaveBeenCalledTimes(1))
+    const preventDefault = vi.fn()
 
-      // Immediate second click - debounce should block it
-      await screen.getByTestId('team1Score').click()
-      await vi.waitFor(() => {
-        // Still only 1 call because of debounce
-        expect(onScore).toHaveBeenCalledTimes(1)
-      })
+    await vi.waitFor(() => {
+      expect(handler).not.toBeNull()
     })
+
+    const currentHandler = handler as unknown as (event: KeyboardEvent) => void
+
+    currentHandler({
+      key: 'ArrowLeft',
+      ctrlKey: false,
+      metaKey: false,
+      altKey: false,
+      preventDefault,
+      target: document.body
+    } as unknown as KeyboardEvent)
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
   })
 
-  describe('keyboard event edge cases', () => {
-    test('processes keyboard events when target is not an HTMLElement (null)', async () => {
-      const onScore = vi.fn()
-      const options = createOptions(session)
-      const callbacks = { onScore }
+  test('ignores unmapped keys, modifier keys, and editable targets', async () => {
+    const onAdd = vi.fn()
+    let handler: ((event: KeyboardEvent) => void) | null = null
 
-      await render(<InputHandlerTestComponent options={options} callbacks={callbacks} />)
+    await render(
+      <InputHandlerHarness
+        onAdd={onAdd}
+        onStateChange={(state) => {
+          handler = state.handlers.onKeyDown
+        }}
+      />
+    )
 
-      // Dispatch keyboard event with a non-HTMLElement target (like window)
-      const event = new KeyboardEvent('keydown', { key: 'ArrowLeft' })
-      Object.defineProperty(event, 'target', { value: null })
-      window.dispatchEvent(event)
-
-      await vi.waitFor(() => expect(onScore).toHaveBeenCalledWith('team-1'))
+    await vi.waitFor(() => {
+      expect(handler).not.toBeNull()
     })
 
-    test('ignores keyboard events when target is an input element', async () => {
-      const onScore = vi.fn()
-      const options = createOptions(session)
-      const callbacks = { onScore }
+    const currentHandler = handler as unknown as (event: KeyboardEvent) => void
 
-      // Create a mock input element
-      const input = document.createElement('input')
-      document.body.appendChild(input)
+    currentHandler({
+      key: 'b',
+      ctrlKey: false,
+      metaKey: false,
+      altKey: false,
+      preventDefault: vi.fn(),
+      target: document.body
+    } as unknown as KeyboardEvent)
+    currentHandler({
+      key: 'ArrowLeft',
+      ctrlKey: true,
+      metaKey: false,
+      altKey: false,
+      preventDefault: vi.fn(),
+      target: document.body
+    } as unknown as KeyboardEvent)
 
-      try {
-        await render(<InputHandlerTestComponent options={options} callbacks={callbacks} />)
+    const input = document.createElement('input')
+    currentHandler({
+      key: 'ArrowLeft',
+      ctrlKey: false,
+      metaKey: false,
+      altKey: false,
+      preventDefault: vi.fn(),
+      target: input
+    } as unknown as KeyboardEvent)
 
-        // Focus on input and dispatch keyboard event
-        input.focus()
-        const event = new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true })
-        input.dispatchEvent(event)
+    expect(onAdd).not.toHaveBeenCalled()
+  })
 
-        await vi.waitFor(() => {
-          // Should NOT trigger because target is an INPUT element
-          expect(onScore).not.toHaveBeenCalled()
-        })
-      } finally {
-        document.body.removeChild(input)
-      }
+  test('treats non-HTMLElement targets as non-editable', async () => {
+    vi.useFakeTimers()
+
+    let handler: ((event: KeyboardEvent) => void) | null = null
+    const onAdd = vi.fn()
+
+    await render(
+      <InputHandlerHarness
+        onAdd={onAdd}
+        onStateChange={(state) => {
+          handler = state.handlers.onKeyDown
+        }}
+      />
+    )
+
+    await vi.waitFor(() => {
+      expect(handler).not.toBeNull()
     })
 
-    test('ignores keyboard events when target is a textarea element', async () => {
-      const onScore = vi.fn()
-      const options = createOptions(session)
-      const callbacks = { onScore }
+    const currentHandler = handler as unknown as (event: KeyboardEvent) => void
+    const textNode = document.createTextNode('target')
 
-      // Create a mock textarea element
-      const textarea = document.createElement('textarea')
-      document.body.appendChild(textarea)
+    currentHandler({
+      key: 'ArrowLeft',
+      ctrlKey: false,
+      metaKey: false,
+      altKey: false,
+      preventDefault: vi.fn(),
+      target: textNode
+    } as unknown as KeyboardEvent)
 
-      try {
-        await render(<InputHandlerTestComponent options={options} callbacks={callbacks} />)
+    await vi.advanceTimersByTimeAsync(380)
 
-        // Focus on textarea and dispatch keyboard event
-        textarea.focus()
-        const event = new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true })
-        textarea.dispatchEvent(event)
+    expect(onAdd).toHaveBeenCalledWith('team-1')
+  })
 
-        await vi.waitFor(() => {
-          // Should NOT trigger because target is a TEXTAREA element
-          expect(onScore).not.toHaveBeenCalled()
-        })
-      } finally {
-        document.body.removeChild(textarea)
-      }
-    })
+  test('touch handlers remain immediate and do not use the buffer', async () => {
+    const onAdd = vi.fn()
+    const screen = await render(<InputHandlerHarness onAdd={onAdd} />)
 
-    test('ignores keyboard events when target is contentEditable', async () => {
-      const onScore = vi.fn()
-      const options = createOptions(session)
-      const callbacks = { onScore }
+    await screen.getByTestId('touch-add-team-1').click()
 
-      // Create a mock contentEditable div
-      const div = document.createElement('div')
-      div.contentEditable = 'true'
-      document.body.appendChild(div)
+    expect(onAdd).toHaveBeenCalledWith('team-1')
+    await expect.element(screen.getByTestId('action-count')).toHaveTextContent('1')
+  })
 
-      try {
-        await render(<InputHandlerTestComponent options={options} callbacks={callbacks} />)
+  test('touch team-2 scoring remains immediate', async () => {
+    const onAdd = vi.fn()
 
-        // Focus on div and dispatch keyboard event
-        div.focus()
-        const event = new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true })
-        div.dispatchEvent(event)
+    function Team2Harness() {
+      const [actions, setActions] = useState<MatchAction[]>([])
+      const state = useInputHandler(
+        {
+          actions
+        },
+        {
+          onAdd: async (teamId) => {
+            setActions((currentActions) => [...currentActions, { type: 'score-point', teamId }])
+            onAdd(teamId)
+          },
+          onUndo: async () => undefined,
+          onUndoForTeam: async () => undefined
+        }
+      )
 
-        await vi.waitFor(() => {
-          // Should NOT trigger because target is contentEditable
-          expect(onScore).not.toHaveBeenCalled()
-        })
-      } finally {
-        document.body.removeChild(div)
-      }
+      return (
+        <button type="button" data-testid="touch-add-team-2" onClick={state.handlers.onTeam2Score}>
+          Add team 2
+        </button>
+      )
+    }
+
+    const screen = await render(<Team2Harness />)
+
+    await screen.getByTestId('touch-add-team-2').click()
+
+    expect(onAdd).toHaveBeenCalledWith('team-2')
+  })
+
+  test('touch undo handler works immediately when enabled', async () => {
+    const onUndo = vi.fn()
+    const screen = await render(
+      <InputHandlerHarness
+        initialActions={[{ type: 'score-point', teamId: 'team-1' }]}
+        onUndo={onUndo}
+      />
+    )
+
+    await screen.getByTestId('touch-undo').click()
+
+    expect(onUndo).toHaveBeenCalledTimes(1)
+    await expect.element(screen.getByTestId('action-count')).toHaveTextContent('0')
+  })
+
+  test('ignores mapped keyboard input when the handler is disabled', async () => {
+    vi.useFakeTimers()
+
+    const onAdd = vi.fn()
+    await render(<InputHandlerHarness enabled={false} onAdd={onAdd} />)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect(onAdd).not.toHaveBeenCalled()
+  })
+
+  test('ignores touch handlers when the hook is disabled', async () => {
+    const onAdd = vi.fn()
+    const onUndo = vi.fn()
+    const screen = await render(
+      <InputHandlerHarness
+        enabled={false}
+        onAdd={onAdd}
+        onUndo={onUndo}
+        initialActions={[{ type: 'score-point', teamId: 'team-1' }]}
+      />
+    )
+
+    await screen.getByTestId('touch-add-team-1').click()
+    await screen.getByTestId('touch-add-team-2').click()
+    await screen.getByTestId('touch-undo').click()
+
+    expect(onAdd).not.toHaveBeenCalled()
+    expect(onUndo).not.toHaveBeenCalled()
+  })
+
+  test('team-specific revert keeps state unchanged when that team has no actions', async () => {
+    const onUndoForTeam = vi.fn()
+    const screen = await render(
+      <InputHandlerHarness
+        onUndoForTeam={onUndoForTeam}
+        bindings={{
+          'add-team-1': 'q',
+          'revert-team-1': 'z',
+          'add-team-2': 'w',
+          'revert-team-2': 'x'
+        }}
+      />
+    )
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z' }))
+
+    expect(onUndoForTeam).toHaveBeenCalledWith('team-1')
+    await expect.element(screen.getByTestId('action-count')).toHaveTextContent('0')
+  })
+
+  test('global undo cancels a pending buffered add before it is committed', async () => {
+    vi.useFakeTimers()
+
+    const onAdd = vi.fn()
+    const onUndo = vi.fn()
+
+    await render(<InputHandlerHarness onAdd={onAdd} onUndo={onUndo} />)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect(onAdd).not.toHaveBeenCalled()
+    expect(onUndo).not.toHaveBeenCalled()
+  })
+
+  test('reports callback errors through onError', async () => {
+    const onError = vi.fn()
+
+    function ErrorHarness() {
+      const state = useInputHandler(
+        {
+          actions: [],
+          bufferedAddWindowMs: 10
+        },
+        {
+          onAdd: async () => {
+            throw new Error('score failed')
+          },
+          onUndo: async () => undefined,
+          onUndoForTeam: async () => undefined,
+          onError
+        }
+      )
+
+      return (
+        <button type="button" data-testid="error-button" onClick={state.handlers.onTeam1Score}>
+          Error
+        </button>
+      )
+    }
+
+    const screen = await render(<ErrorHarness />)
+
+    await screen.getByTestId('error-button').click()
+
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'score failed' }))
     })
   })
 })


### PR DESCRIPTION
## Summary

Adds support for a Bluetooth remote controller to drive team scoring and undo actions.

This PR introduces a configurable remote controller system, persistence for bindings using IndexedDB, a buffered "add" window (~380ms) to allow double-press undo behavior per-team, backward compatibility with legacy keyboard shortcuts, and full i18n for English, Spanish, and Portuguese.

## Major changes

- New remote controller UI in the Setup screen allowing users to map controller buttons to actions (team A add, team B add, undo, etc.)
- IndexedDB-backed storage for saved bindings to persist across sessions
- Input buffering logic to detect quick double-presses and apply team-specific undo when appropriate
- i18n strings and translation files for EN, ES, PT
- Tests for the remote controller bindings storage and buffering logic

## Files added/modified

$FILE_LIST

## Tests

- Unit tests covering IndexedDB persistence and binding serialization
- Unit tests for buffered input behavior and double-press detection
- Integration test skeletons for end-to-end verification of controller-driven scoring

## Known limitations

- Bluetooth pairing is handled by the OS; this implementation expects the controller to be available as a keyboard-like HID device
- Some browsers/platforms may require additional permissions for HID access; tests are limited to the environments configured in CI
- UX for remapping may be further improved (visual feedback during binding capture)

## Notes for reviewers

- Focus on the SetupScreen changes for binding UX and on the persistence layer for correctness
- Ensure i18n keys are consistent and translations are present for all added keys