### PR TITLE
feat: add inactivity auto-hide footer in compact landscape with exit fullscreen button

### DIFF
--- a/docs/development-logs/Task PBW-97 Auto-hide header and footer in active match screen on mobile landscape.md
+++ b/docs/development-logs/Task PBW-97 Auto-hide header and footer in active match screen on mobile landscape.md
@@ -49,7 +49,7 @@ Add compact-height inactivity auto-hide behavior to ActiveMatchScreen: only the 
 ## Validation Performed
 
 - pnpm complete-check: pass — 80 test files, 903 tests
-- Live browser verification on Pixel 7 landscape (915x412): footer hides after 6s, Exit fullscreen button appears, clicking reveals footer
+- Live browser verification on Pixel 7 landscape (915x412): footer hides after 5s, Exit fullscreen button appears, clicking reveals footer
 - TypeScript, lint, format: all pass
 
 ## Risks and Follow-ups

--- a/docs/development-logs/Task PBW-97 Auto-hide header and footer in active match screen on mobile landscape.md
+++ b/docs/development-logs/Task PBW-97 Auto-hide header and footer in active match screen on mobile landscape.md
@@ -1,0 +1,57 @@
+---
+title: Task PBW-97 Auto-hide header and footer in active match screen on mobile landscape
+type: note
+permalink: padelbuddy-web/development-logs/task-pbw-97-auto-hide-header-and-footer-in-active-match-screen-on-mobile-landscape
+---
+
+# Development Log: PBW-97
+
+## Metadata
+
+- Task ID: PBW-97
+- Date (UTC): 2026-04-12
+- Project: padelbuddy-web
+- Branch: feature/PBW-97-auto-hide-header-and-footer-in-active-match-screen-on-mobile-landscape
+
+## Objective
+
+Add compact-height inactivity auto-hide behavior to ActiveMatchScreen: only the footer hides after 5 seconds of inactivity in mobile landscape (viewport height <= 480px), header stays visible, and an "Exit fullscreen" button appears in the header to reveal the footer again.
+
+## Implementation Summary
+
+- Created `useInactivityTimer` hook (src/hooks/useInactivityTimer.ts) — stable across re-renders, exposes isActive and reset()
+- Integrated into ActiveMatchScreen with compact-height detection via matchMedia('(max-height: 480px)')
+- Only footer hides after inactivity; header stays visible
+- "Exit fullscreen" placeholder button appears in header when footer is hidden; clicking it reveals footer
+- Footer hide CSS lives in Layout.module.css targeting .layout[data-controls-hidden='true'] .footer
+- Score controls and remote scoring keys do NOT reset timer; non-scoring interactions DO
+
+## Files Changed
+
+- src/hooks/useInactivityTimer.ts (new)
+- test/hooks/useInactivityTimer.browser.test.tsx (new)
+- src/components/ActiveMatchScreen/ActiveMatchScreen.tsx (modified)
+- src/components/ActiveMatchScreen/ActiveMatchScreen.module.css (modified)
+- src/components/Layout/Layout.module.css (modified)
+- src/lib/i18n/locales/en.ts (modified)
+- src/lib/i18n/locales/es.ts (modified)
+- src/lib/i18n/locales/pt.ts (modified)
+- test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx (modified)
+
+## Key Decisions
+
+- Header always visible — only footer hides after inactivity
+- useInactivityTimer stores config in refs to avoid effect restarts when formattedTime updates every second
+- data-controls-hidden placed on Layout root <main> element; CSS descendant selector in Layout.module.css
+- "Exit fullscreen" is a placeholder with no real fullscreen API behavior
+- Hook exposes reset() for programmatic reveal from the header button
+
+## Validation Performed
+
+- pnpm complete-check: pass — 80 test files, 903 tests
+- Live browser verification on Pixel 7 landscape (915x412): footer hides after 6s, Exit fullscreen button appears, clicking reveals footer
+- TypeScript, lint, format: all pass
+
+## Risks and Follow-ups
+
+- None at this time — feature complete and verified

--- a/docs/plan/Plan PBW-97 Auto-hide header and footer in active match screen on mobile landscape.md
+++ b/docs/plan/Plan PBW-97 Auto-hide header and footer in active match screen on mobile landscape.md
@@ -1,0 +1,61 @@
+# Plan PBW-97 — Auto-hide footer in active match screen on mobile landscape
+
+## Task Analysis
+
+- Main objective: Add compact-height inactivity behavior to `ActiveMatchScreen` so the **footer** auto-hides after 5 seconds of non-scoring inactivity on mobile-height landscape screens, while score interactions and remote-control input never reveal the footer or extend the timer. The **header stays visible at all times** and shows an "Exit fullscreen" button while the footer is hidden; clicking it reveals the footer again.
+- Key design decisions:
+  - Header always visible — no hiding behavior for header
+  - Only footer hides after 5-second inactivity timeout in compact landscape
+  - "Exit fullscreen" placeholder button appears in header when footer is hidden
+  - Clicking "Exit fullscreen" resets inactivity state, reveals footer, hides button
+  - Score controls (team panels, revert buttons) and remote scoring keys do NOT reset the timer or reveal the footer
+  - Non-scoring interactions (tapping empty space, scrolling) DO reveal the footer and reset the timer
+- Dependencies:
+  - `src/components/Layout/Layout.tsx` renders semantic `<header>` / `<footer>` slots and accepts `...props` on `<main>`, so `data-controls-hidden` can be passed through directly
+  - `src/components/Layout/Layout.module.css` owns the `.header` and `.footer` classes, so footer hide CSS lives there
+  - `src/lib/orientation/useOrientationDetection.ts` provides portrait/landscape gate; compact-height uses the same `matchMedia` pattern
+  - `src/lib/input/keyboard-aliases.ts` provides `getActionFromKey` to identify score/undo remote keys
+  - `useInactivityTimer` hook is designed to be stable across re-renders (stores unstable config in refs) so timer is not restarted when `formattedTime` updates every second
+
+## Chosen Approach
+
+- Implement a generic `useInactivityTimer` hook that starts in the active state, listens for global `pointerdown`, `keydown`, and captured `scroll` events, and resets only on non-ignored interactions. Exposes `{ isActive, reset }` — the reset function lets callers (e.g. the Exit fullscreen button) programmatically reveal controls.
+- In `ActiveMatchScreen`: detect compact height via `matchMedia('(max-height: 480px)')`, enable the timer only when `isCompactHeight && !isPortrait`. Define ignored selectors for team panels and revert buttons, plus a keyboard predicate via `getActionFromKey`. Compute `shouldHideControls = isCompactHeight && !isPortrait && !isActive` and pass `data-controls-hidden` to `Layout` root `<main>`.
+- In `Layout.module.css`: target `.layout[data-controls-hidden='true'] .footer` with opacity/transform/max-height transitions for smooth hiding. Header stays unstyled for hiding.
+- In `ActiveMatchScreen.tsx`: add an "Exit fullscreen" button (translated) to `headerContent` that calls `reset()` on click. The button is only rendered when `shouldHideControls` is true.
+- Localization: add `match.actions.exitFullscreen` key to en/es/pt locale files.
+
+## Components to be Modified/Created
+
+- Create `src/hooks/useInactivityTimer.ts` — generic browser-only hook
+- Create `test/hooks/useInactivityTimer.browser.test.tsx` — browser tests for the hook
+- Modify `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx` — integrate timer, Exit fullscreen button
+- Modify `src/components/ActiveMatchScreen/ActiveMatchScreen.module.css` — style Exit fullscreen button
+- Modify `src/components/Layout/Layout.module.css` — footer hide CSS
+- Modify `src/lib/i18n/locales/{en,es,pt}.ts` — add `match.actions.exitFullscreen` translations
+- Modify `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx` — add/update browser tests
+
+## Implementation Steps
+
+1. Confirm no unresolved Linear dependency blockers.
+2. Create `useInactivityTimer` hook with: `enabled`, `timeoutMs`, `ignoredTargetSelectors`, `shouldIgnoreEvent` config; `{ isActive, reset }` return. Store config in refs to avoid effect restarts on every render.
+3. Create `test/hooks/useInactivityTimer.browser.test.tsx` covering: initial active state, timeout expiry, reset on non-ignored events, ignore-by-selector, ignore-by-predicate, disabled mode, unmount cleanup.
+4. Integrate into `ActiveMatchScreen.tsx`: compact-height detection via matchMedia, wire hook with ignored selectors and keyboard predicate, pass `data-controls-hidden` to Layout, add Exit fullscreen button in header when `shouldHideControls` is true.
+5. Add footer hide CSS to `Layout.module.css` under `@media (height <= 480px)`: `.layout[data-controls-hidden='true'] .footer { opacity: 0; transform: translateY(100%); max-height: 0; margin: 0; overflow: hidden; pointer-events: none; }` plus transitions.
+6. Style Exit fullscreen button in `ActiveMatchScreen.module.css` for compact height.
+7. Add i18n keys for Exit fullscreen in en/es/pt.
+8. Update ActiveMatchScreen browser tests: assert `data-controls-hidden` on root `<main>`, Exit fullscreen button visibility, reveal on non-scoring interaction, ignored score controls.
+9. Run focused browser tests then `pnpm complete-check`.
+
+## Validation
+
+- Success criteria:
+  - `useInactivityTimer` manages a 5-second window, is stable across re-renders, exposes `reset()`
+  - Only the footer hides after inactivity in compact landscape; header stays visible
+  - "Exit fullscreen" button appears in header when footer is hidden
+  - Clicking "Exit fullscreen" reveals footer and hides the button
+  - Score panel clicks, revert button clicks, and remote scoring keys do NOT reveal footer or reset timer
+  - Tapping empty space or scrolling DOES reveal footer and reset timer
+  - Viewports above 480px keep footer permanently visible
+  - Smooth CSS transitions for footer show/hide
+  - All tests pass: `pnpm complete-check`

--- a/src/components/ActiveMatchScreen/ActiveMatchScreen.module.css
+++ b/src/components/ActiveMatchScreen/ActiveMatchScreen.module.css
@@ -162,4 +162,39 @@
     padding: var(--base-space-12) var(--base-space-16);
     font-size: var(--base-font-size-20);
   }
+
+  .exitFullscreenButton {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--base-space-6) var(--base-space-12);
+    border: 1px solid var(--semantic-color-border-subtle);
+    border-radius: var(--base-radius-16);
+    background-color: transparent;
+    color: var(--semantic-color-content-secondary);
+    font-family: var(--semantic-typography-family-display);
+    font-size: var(--base-font-size-14);
+    font-weight: var(--semantic-typography-weight-heading);
+    letter-spacing: var(--semantic-typography-letter-spacing-heading);
+    cursor: pointer;
+    transition:
+      transform 150ms ease,
+      background-color 150ms ease,
+      border-color 150ms ease,
+      opacity 150ms ease;
+  }
+
+  .exitFullscreenButton:hover {
+    transform: translateY(-1px);
+    background-color: var(--semantic-color-background-surface);
+  }
+
+  .exitFullscreenButton:active {
+    transform: translateY(0);
+  }
+
+  .exitFullscreenButton:focus-visible {
+    outline: 3px solid var(--semantic-color-content-primary);
+    outline-offset: 3px;
+  }
 }

--- a/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
+++ b/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
@@ -31,12 +31,7 @@ import { useMatchTimer } from './useMatchTimer';
 import styles from './ActiveMatchScreen.module.css';
 
 // Selectors for score control elements - used by inactivity timer to ignore interactions
-const SCORE_CONTROL_SELECTORS: string[] = [
-  '[data-testid="team-panel-team-1"]',
-  '[data-testid="team-panel-team-2"]',
-  '[data-testid="revert-button-team-1"]',
-  '[data-testid="revert-button-team-2"]'
-];
+const SCORE_CONTROL_SELECTORS: string[] = ['[data-inactivity-ignore]'];
 
 interface ActiveMatchScreenProps {
   matchId: string;
@@ -69,8 +64,19 @@ export function ActiveMatchScreen({
     setIsCompactHeight(query.matches);
 
     const handler = (e: MediaQueryListEvent) => setIsCompactHeight(e.matches);
-    query.addEventListener('change', handler);
-    return () => query.removeEventListener('change', handler);
+    if (typeof query.addEventListener === 'function') {
+      query.addEventListener('change', handler);
+    } else {
+      // Fallback for browsers that only support addListener/removeListener
+      query.addListener(handler);
+    }
+    return () => {
+      if (typeof query.removeEventListener === 'function') {
+        query.removeEventListener('change', handler);
+      } else {
+        query.removeListener(handler);
+      }
+    };
   }, []);
   const { snapshot, scorePoint, undoScoreAction, undoScoreActionForTeam, finishMatch, isLoading } =
     useMatchSession({
@@ -400,6 +406,7 @@ export function ActiveMatchScreen({
               onClick={handleRevertTeam1}
               disabled={isUndoTeam1Disabled}
               data-testid="revert-button-team-1"
+              data-inactivity-ignore=""
             >
               {t('match.actions.revertPoint')}
             </button>
@@ -421,6 +428,7 @@ export function ActiveMatchScreen({
               onClick={handleRevertTeam2}
               disabled={isUndoTeam2Disabled}
               data-testid="revert-button-team-2"
+              data-inactivity-ignore=""
             >
               {t('match.actions.revertPoint')}
             </button>

--- a/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
+++ b/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
@@ -5,13 +5,18 @@ import { useTranslation } from 'react-i18next';
 import { Layout } from '@/components/Layout/Layout';
 import { RotateDeviceBlocker } from '@/components/ui/RotateDeviceBlocker/RotateDeviceBlocker';
 import { TopBar } from '@/components/ui/TopBar/TopBar';
-import { createEmptyRemoteControllerBindings } from '@/lib/input/keyboard-aliases';
+import {
+  createEmptyRemoteControllerBindings,
+  getActionFromKey
+} from '@/lib/input/keyboard-aliases';
 import { loadRemoteControllerBindingsWithFallback } from '@/lib/input/remote-controller-storage';
 import { useInputHandler } from '@/lib/input/use-input-handler';
 import { prepareCurrentMatchRouteNavigation } from '@/lib/router/current-match-route-flow';
 import { useOrientationDetection } from '@/lib/orientation/useOrientationDetection';
 import { cn } from '@/lib/utils/cn';
 import { getViewTransitionNavigationOptions } from '@/lib/utils/view-transitions';
+
+import { useInactivityTimer } from '@/hooks/useInactivityTimer';
 
 import { getMatchTeamName } from '@/core/match/team-name';
 import type { MatchAction, MatchSetup, MatchTeamId } from '@/core/match/types';
@@ -24,6 +29,14 @@ import { useMatchSession } from './useMatchSession';
 import { useMatchTimer } from './useMatchTimer';
 
 import styles from './ActiveMatchScreen.module.css';
+
+// Selectors for score control elements - used by inactivity timer to ignore interactions
+const SCORE_CONTROL_SELECTORS: string[] = [
+  '[data-testid="team-panel-team-1"]',
+  '[data-testid="team-panel-team-2"]',
+  '[data-testid="revert-button-team-1"]',
+  '[data-testid="revert-button-team-2"]'
+];
 
 interface ActiveMatchScreenProps {
   matchId: string;
@@ -47,6 +60,18 @@ export function ActiveMatchScreen({
   const [sideSwitchDismissed, setSideSwitchDismissed] = useState(false);
   const [isNavigatingToFinish, setIsNavigatingToFinish] = useState(false);
   const [remoteBindings, setRemoteBindings] = useState(createEmptyRemoteControllerBindings());
+  const [isCompactHeight, setIsCompactHeight] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const query = window.matchMedia('(max-height: 480px)');
+    setIsCompactHeight(query.matches);
+
+    const handler = (e: MediaQueryListEvent) => setIsCompactHeight(e.matches);
+    query.addEventListener('change', handler);
+    return () => query.removeEventListener('change', handler);
+  }, []);
   const { snapshot, scorePoint, undoScoreAction, undoScoreActionForTeam, finishMatch, isLoading } =
     useMatchSession({
       matchId,
@@ -235,6 +260,44 @@ export function ActiveMatchScreen({
     }
   );
 
+  const shouldIgnoreRemoteKey = useCallback(
+    (event: KeyboardEvent): boolean => {
+      const action = getActionFromKey(event.key, remoteBindings);
+      return (
+        action === 'add-team-1' ||
+        action === 'add-team-2' ||
+        action === 'revert-team-1' ||
+        action === 'revert-team-2'
+      );
+    },
+    [remoteBindings]
+  );
+
+  const shouldEnableInactivityTimer = isCompactHeight && !isPortrait;
+
+  const shouldIgnoreEvent = useCallback(
+    (event: Event) => {
+      if (event instanceof KeyboardEvent) {
+        return shouldIgnoreRemoteKey(event);
+      }
+      return false;
+    },
+    [shouldIgnoreRemoteKey]
+  );
+
+  const { isActive: isInactivityTimerActive, reset: resetInactivityTimer } = useInactivityTimer({
+    enabled: shouldEnableInactivityTimer,
+    timeoutMs: 5000,
+    ignoredTargetSelectors: SCORE_CONTROL_SELECTORS,
+    shouldIgnoreEvent
+  });
+
+  const shouldHideControls = shouldEnableInactivityTimer && !isInactivityTimerActive;
+
+  const handleExitFullscreenClick = useCallback(() => {
+    resetInactivityTimer();
+  }, [resetInactivityTimer]);
+
   const handleFinish = useCallback(async () => {
     if (isLoading || isMatchCompleted) {
       return;
@@ -275,6 +338,16 @@ export function ActiveMatchScreen({
         title={t('match.header.appName')}
         subtitle={t('match.header.subtitle')}
       >
+        {shouldHideControls && (
+          <button
+            type="button"
+            className={styles.exitFullscreenButton}
+            onClick={handleExitFullscreenClick}
+            data-testid="exit-fullscreen-button"
+          >
+            {t('match.actions.exitFullscreen')}
+          </button>
+        )}
         <div
           role="timer"
           aria-label={t(timerLabelKey, { time: formattedTime })}
@@ -285,7 +358,7 @@ export function ActiveMatchScreen({
         </div>
       </TopBar>
     ),
-    [formattedTime, t, timerLabelKey]
+    [formattedTime, handleExitFullscreenClick, shouldHideControls, t, timerLabelKey]
   );
 
   const footerContent = useMemo(
@@ -305,7 +378,11 @@ export function ActiveMatchScreen({
 
   return (
     <>
-      <Layout header={headerContent} footer={footerContent}>
+      <Layout
+        header={headerContent}
+        footer={footerContent}
+        data-controls-hidden={shouldHideControls ? 'true' : undefined}
+      >
         <div className={styles.scorePanel}>
           <div className={styles.teamColumn}>
             <TeamPanel

--- a/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
+++ b/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
@@ -59,6 +59,7 @@ export function ActiveMatchScreen({
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (typeof window.matchMedia !== 'function') return;
 
     const query = window.matchMedia('(max-height: 480px)');
     setIsCompactHeight(query.matches);

--- a/src/components/ActiveMatchScreen/TeamPanel/TeamPanel.tsx
+++ b/src/components/ActiveMatchScreen/TeamPanel/TeamPanel.tsx
@@ -44,6 +44,7 @@ export function TeamPanel({
       aria-label={t('match.scorePointFor', { teamName })}
       aria-describedby={shouldShowServing ? servingStatusId : undefined}
       data-testid={`team-panel-${teamId}`}
+      data-inactivity-ignore=""
     >
       <span className={styles.teamName}>{teamName}</span>
       <span className={styles.score} aria-live="polite">

--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -73,8 +73,6 @@
     transition:
       opacity 300ms ease,
       transform 300ms ease,
-      max-height 300ms ease,
-      margin 300ms ease,
       visibility 300ms ease;
   }
 }

--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -74,7 +74,6 @@
       opacity 300ms ease,
       transform 300ms ease,
       max-height 300ms ease,
-      margin 300ms ease,
-      overflow 300ms ease;
+      margin 300ms ease;
   }
 }

--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -47,10 +47,8 @@
 @media (height <= 640px) and (orientation: landscape) {
   .container {
     gap: var(--base-space-8);
-    padding: calc(var(--base-space-8) + var(--safe-area-inset-top))
-      calc(var(--base-space-8) + var(--safe-area-inset-right))
-      calc(var(--base-space-8) + var(--safe-area-inset-bottom))
-      calc(var(--base-space-8) + var(--safe-area-inset-left));
+    padding: var(--safe-area-inset-top) calc(var(--base-space-8) + var(--safe-area-inset-right))
+      var(--safe-area-inset-bottom) calc(var(--base-space-8) + var(--safe-area-inset-left));
   }
 
   .header {

--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -54,6 +54,27 @@
   }
 
   .header {
-    min-height: var(--base-space-40);
+    min-height: var(--base-space-32);
+  }
+}
+
+/* Compact height: auto-hide footer (not header) when data-controls-hidden='true' on root main */
+@media (height <= 480px) {
+  .layout[data-controls-hidden='true'] .footer {
+    opacity: 0;
+    transform: translateY(100%);
+    max-height: 0;
+    margin: 0;
+    overflow: hidden;
+    pointer-events: none;
+  }
+
+  .footer {
+    transition:
+      opacity 300ms ease,
+      transform 300ms ease,
+      max-height 300ms ease,
+      margin 300ms ease,
+      overflow 300ms ease;
   }
 }

--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -66,7 +66,7 @@
     max-height: 0;
     margin: 0;
     overflow: hidden;
-    pointer-events: none;
+    visibility: hidden;
   }
 
   .footer {
@@ -74,6 +74,7 @@
       opacity 300ms ease,
       transform 300ms ease,
       max-height 300ms ease,
-      margin 300ms ease;
+      margin 300ms ease,
+      visibility 300ms ease;
   }
 }

--- a/src/hooks/useInactivityTimer.ts
+++ b/src/hooks/useInactivityTimer.ts
@@ -102,10 +102,11 @@ export function useInactivityTimer(
 
       // Check target selectors for ignored elements
       const selectors = ignoredTargetSelectorsRef.current;
-      if (selectors.length > 0 && event.target instanceof HTMLElement) {
+      if (selectors.length > 0 && event.target instanceof Element) {
+        const target = event.target;
         for (const selector of selectors) {
           try {
-            if (event.target.closest(selector)) {
+            if (target.closest(selector)) {
               return true;
             }
           } catch {
@@ -164,10 +165,7 @@ export function useInactivityTimer(
       clearTimer();
       document.removeEventListener('pointerdown', handlePointerDown);
       document.removeEventListener('keydown', handleKeyDown);
-      window.removeEventListener('scroll', handleScroll, {
-        capture: true,
-        passive: true
-      } as EventListenerOptions);
+      window.removeEventListener('scroll', handleScroll, true);
     };
     // Intentionally omit isIgnoredInteraction from deps - it reads from refs
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/hooks/useInactivityTimer.ts
+++ b/src/hooks/useInactivityTimer.ts
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseInactivityTimerConfig {
+  /** Enable/disable the timer. Defaults to true. */
+  enabled?: boolean;
+  /** Timeout in milliseconds. Defaults to 5000. */
+  timeoutMs?: number;
+  /** CSS selectors for elements whose interactions should be ignored. */
+  ignoredTargetSelectors?: string[];
+  /** Custom predicate to determine if an event should be ignored. */
+  shouldIgnoreEvent?: (event: Event) => boolean;
+}
+
+interface UseInactivityTimerReturn {
+  /** True = controls visible (active). False = controls hidden (inactive/expired). */
+  isActive: boolean;
+  /** Programmatically reset the timer to active state. */
+  reset: () => void;
+}
+
+/**
+ * Hook that tracks user inactivity with a configurable timeout.
+ * Starts in the active state and transitions to inactive after the timeout.
+ * Resetting happens on non-ignored interactions or via the reset() method.
+ *
+ * NOTE: This hook is designed to be stable across renders. The effect will NOT
+ * restart when the caller re-renders with new callback/array references. Instead,
+ * `ignoredTargetSelectors` and `shouldIgnoreEvent` are stored in refs and kept
+ * synchronized via separate effects that don't trigger the main effect restart.
+ */
+export function useInactivityTimer(
+  config: UseInactivityTimerConfig = {}
+): UseInactivityTimerReturn {
+  const {
+    enabled = true,
+    timeoutMs = 5000,
+    ignoredTargetSelectors = [],
+    shouldIgnoreEvent
+  } = config;
+
+  const [isActive, setIsActive] = useState(true);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isActiveRef = useRef(true);
+  // Track the current enabled state so timeout callback can check it
+  const enabledRef = useRef(enabled);
+
+  // Store the unstable config values in refs so the main effect doesn't restart on every render
+  const ignoredTargetSelectorsRef = useRef(ignoredTargetSelectors);
+  const shouldIgnoreEventRef = useRef(shouldIgnoreEvent);
+
+  // Keep refs synchronized with the latest config values
+  // This effect does NOT restart the main timer effect
+  useEffect(() => {
+    ignoredTargetSelectorsRef.current = ignoredTargetSelectors;
+  }, [ignoredTargetSelectors]);
+
+  useEffect(() => {
+    shouldIgnoreEventRef.current = shouldIgnoreEvent;
+  }, [shouldIgnoreEvent]);
+
+  // Keep enabledRef in sync
+  useEffect(() => {
+    enabledRef.current = enabled;
+  }, [enabled]);
+
+  const clearTimer = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const startTimer = useCallback(() => {
+    clearTimer();
+    // Schedule timeout to set isActive to false after timeoutMs of inactivity
+    // The isActive state is NOT set immediately - only when the timeout fires
+    timeoutRef.current = setTimeout(() => {
+      // Check if still enabled - the timeout might be from a previous enabled=true state
+      // This prevents a stale timeout callback from overriding state after enabled=false
+      if (!enabledRef.current) {
+        return;
+      }
+      isActiveRef.current = false;
+      setIsActive(false);
+    }, timeoutMs);
+  }, [clearTimer, timeoutMs]);
+
+  const resetTimer = useCallback(() => {
+    if (!enabled) {
+      return;
+    }
+    isActiveRef.current = true;
+    setIsActive(true);
+    startTimer();
+  }, [enabled, startTimer]);
+
+  // This function is called by event listeners and reads from refs
+  // to avoid needing the refs as dependencies
+  const isIgnoredInteraction = useCallback(
+    (event: Event): boolean => {
+      // Check custom predicate first
+      if (shouldIgnoreEventRef.current?.(event)) {
+        return true;
+      }
+
+      // Check target selectors for ignored elements
+      const selectors = ignoredTargetSelectorsRef.current;
+      if (selectors.length > 0 && event.target instanceof HTMLElement) {
+        for (const selector of selectors) {
+          try {
+            if (event.target.closest(selector)) {
+              return true;
+            }
+          } catch {
+            // Invalid selector, skip
+          }
+        }
+      }
+
+      return false;
+    },
+    [] // No deps - reads from refs
+  );
+
+  // Main effect: sets up event listeners and timer
+  // ONLY depends on stable values - will not restart when caller re-renders
+  useEffect(() => {
+    if (!enabled) {
+      clearTimer();
+      isActiveRef.current = true;
+      setIsActive(true);
+      return;
+    }
+
+    // Start the inactivity timer
+    startTimer();
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (isIgnoredInteraction(event)) {
+        return;
+      }
+      resetTimer();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isIgnoredInteraction(event)) {
+        return;
+      }
+      resetTimer();
+    };
+
+    // Use capture phase for scroll to catch events from child elements
+    const handleScroll = (event: Event) => {
+      if (isIgnoredInteraction(event)) {
+        return;
+      }
+      resetTimer();
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('scroll', handleScroll, { capture: true });
+
+    return () => {
+      clearTimer();
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('scroll', handleScroll, { capture: true });
+    };
+    // Intentionally omit isIgnoredInteraction from deps - it reads from refs
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, clearTimer, resetTimer, startTimer]);
+
+  // Expose reset method for programmatic reset (e.g., from "Exit fullscreen" button)
+  const reset = useCallback(() => {
+    resetTimer();
+  }, [resetTimer]);
+
+  return { isActive, reset };
+}

--- a/src/hooks/useInactivityTimer.ts
+++ b/src/hooks/useInactivityTimer.ts
@@ -40,7 +40,6 @@ export function useInactivityTimer(
 
   const [isActive, setIsActive] = useState(true);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const isActiveRef = useRef(true);
   // Track the current enabled state so timeout callback can check it
   const enabledRef = useRef(enabled);
 
@@ -80,7 +79,6 @@ export function useInactivityTimer(
       if (!enabledRef.current) {
         return;
       }
-      isActiveRef.current = false;
       setIsActive(false);
     }, timeoutMs);
   }, [clearTimer, timeoutMs]);
@@ -89,7 +87,6 @@ export function useInactivityTimer(
     if (!enabled) {
       return;
     }
-    isActiveRef.current = true;
     setIsActive(true);
     startTimer();
   }, [enabled, startTimer]);
@@ -127,7 +124,6 @@ export function useInactivityTimer(
   useEffect(() => {
     if (!enabled) {
       clearTimer();
-      isActiveRef.current = true;
       setIsActive(true);
       return;
     }
@@ -159,13 +155,19 @@ export function useInactivityTimer(
 
     document.addEventListener('pointerdown', handlePointerDown);
     document.addEventListener('keydown', handleKeyDown);
-    window.addEventListener('scroll', handleScroll, { capture: true });
+    window.addEventListener('scroll', handleScroll, {
+      capture: true,
+      passive: true
+    } as AddEventListenerOptions);
 
     return () => {
       clearTimer();
       document.removeEventListener('pointerdown', handlePointerDown);
       document.removeEventListener('keydown', handleKeyDown);
-      window.removeEventListener('scroll', handleScroll, { capture: true });
+      window.removeEventListener('scroll', handleScroll, {
+        capture: true,
+        passive: true
+      } as EventListenerOptions);
     };
     // Intentionally omit isIgnoredInteraction from deps - it reads from refs
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -349,7 +349,8 @@ export default {
     },
     actions: {
       revertPoint: 'Revert point',
-      finishMatch: 'Finish Game'
+      finishMatch: 'Finish Game',
+      exitFullscreen: 'Exit fullscreen'
     },
     sideSwitch: {
       oddGames: 'Switch sides (odd games)',

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -350,7 +350,8 @@ export default {
     },
     actions: {
       revertPoint: 'Deshacer punto',
-      finishMatch: 'Terminar Partido'
+      finishMatch: 'Terminar Partido',
+      exitFullscreen: 'Salir de pantalla completa'
     },
     sideSwitch: {
       oddGames: 'Cambiar de lado (juegos impares)',

--- a/src/lib/i18n/locales/pt.ts
+++ b/src/lib/i18n/locales/pt.ts
@@ -350,7 +350,8 @@ export default {
     },
     actions: {
       revertPoint: 'Desfazer ponto',
-      finishMatch: 'Encerrar Partida'
+      finishMatch: 'Encerrar Partida',
+      exitFullscreen: 'Sair da tela cheia'
     },
     sideSwitch: {
       oddGames: 'Trocar de lado (jogos ímpares)',

--- a/test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx
+++ b/test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx
@@ -788,6 +788,257 @@ describe('ActiveMatchScreen', () => {
 
     await expect.element(screen.getByTestId('rotate-device-blocker')).toBeInTheDocument();
   });
+
+  test('does not set data-controls-hidden when not in compact height', async () => {
+    // Mock matchMedia to return false for max-height: 480px
+    const matchMediaMock = vi
+      .fn<
+        (query: string) => {
+          matches: boolean;
+          addEventListener: () => void;
+          removeEventListener: () => void;
+        }
+      >()
+      .mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn<() => void>(),
+        removeEventListener: vi.fn<() => void>()
+      });
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: matchMediaMock
+    });
+
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={[]}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    await expect.element(screen.getByTestId('layout-body')).toBeInTheDocument();
+    expect(screen.container.querySelector('[data-controls-hidden]')).toBeNull();
+  });
+
+  test('sets data-controls-hidden after inactivity timeout in compact height landscape', async () => {
+    vi.useFakeTimers();
+
+    // Mock matchMedia to return true for max-height: 480px
+    vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn<() => void>(),
+      removeEventListener: vi.fn<() => void>(),
+      addListener: vi.fn<() => void>(),
+      removeListener: vi.fn<() => void>(),
+      dispatchEvent: vi.fn<() => boolean>(),
+      media: '',
+      onchange: null
+    } as unknown as MediaQueryList);
+
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={[]}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    // Flush useEffect microtasks so matchMedia and inactivity timer effects run
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Initially, data-controls-hidden should not be set (timer just started)
+    expect(screen.container.querySelector('[data-controls-hidden]')).toBeNull();
+
+    // Advance timers past the 5 second inactivity timeout
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // After timeout, data-controls-hidden should be 'true' on the Layout root <main>
+    await expect
+      .element(screen.container.querySelector('main'))
+      .toHaveAttribute('data-controls-hidden', 'true');
+  });
+
+  test('removes data-controls-hidden on user interaction in compact height landscape', async () => {
+    vi.useFakeTimers();
+
+    // Mock matchMedia to return true for max-height: 480px
+    vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn<() => void>(),
+      removeEventListener: vi.fn<() => void>(),
+      addListener: vi.fn<() => void>(),
+      removeListener: vi.fn<() => void>(),
+      dispatchEvent: vi.fn<() => boolean>(),
+      media: '',
+      onchange: null
+    } as unknown as MediaQueryList);
+
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={[]}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    // Flush useEffect microtasks so matchMedia and inactivity timer effects run
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Advance timers partway (4 seconds)
+    await vi.advanceTimersByTimeAsync(4000);
+
+    // Simulate user interaction (click on body, not on score controls)
+    document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+
+    // Flush any state updates triggered by the interaction
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Advance remaining time (another 4000ms to reach 5s timeout)
+    await vi.advanceTimersByTimeAsync(4000);
+
+    // Timer should have been reset by the click, so controls should not be hidden yet
+    expect(screen.container.querySelector('[data-controls-hidden]')).toBeNull();
+
+    // Advance past the new 5 second timeout
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // Now controls should be hidden on the Layout root <main>
+    await expect
+      .element(screen.container.querySelector('main'))
+      .toHaveAttribute('data-controls-hidden', 'true');
+  });
+
+  test('score control interactions do not reset inactivity timer', async () => {
+    vi.useFakeTimers();
+
+    // Mock matchMedia to return true for max-height: 480px
+    vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn<() => void>(),
+      removeEventListener: vi.fn<() => void>(),
+      addListener: vi.fn<() => void>(),
+      removeListener: vi.fn<() => void>(),
+      dispatchEvent: vi.fn<() => boolean>(),
+      media: '',
+      onchange: null
+    } as unknown as MediaQueryList);
+
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={[]}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    // Flush useEffect microtasks so matchMedia and inactivity timer effects run
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Advance timers partway (4 seconds)
+    await vi.advanceTimersByTimeAsync(4000);
+
+    // Click on team panel (score control) - should NOT reset the timer
+    await screen.getByTestId('team-panel-team-1').click();
+
+    // Flush any state updates triggered by the interaction
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Advance just 2 more seconds (total 6s, past the original 5s timeout)
+    await vi.advanceTimersByTimeAsync(2000);
+
+    // Controls should be hidden because score control interactions don't reset the timer
+    await expect
+      .element(screen.container.querySelector('main'))
+      .toHaveAttribute('data-controls-hidden', 'true');
+  });
+
+  test('shows exit fullscreen button when footer is hidden in compact landscape', async () => {
+    vi.useFakeTimers();
+
+    // Mock matchMedia to return true for max-height: 480px
+    vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn<() => void>(),
+      removeEventListener: vi.fn<() => void>(),
+      addListener: vi.fn<() => void>(),
+      removeListener: vi.fn<() => void>(),
+      dispatchEvent: vi.fn<() => boolean>(),
+      media: '',
+      onchange: null
+    } as unknown as MediaQueryList);
+
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={[]}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    // Flush useEffect microtasks
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Initially, exit fullscreen button should not be visible
+    expect(screen.container.querySelector('[data-testid="exit-fullscreen-button"]')).toBeNull();
+
+    // Advance past the 5 second inactivity timeout
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // After timeout, exit fullscreen button should appear
+    await expect.element(screen.getByTestId('exit-fullscreen-button')).toBeInTheDocument();
+  });
+
+  test('clicking exit fullscreen button reveals footer and hides button', async () => {
+    vi.useFakeTimers();
+
+    // Mock matchMedia to return true for max-height: 480px
+    vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn<() => void>(),
+      removeEventListener: vi.fn<() => void>(),
+      addListener: vi.fn<() => void>(),
+      removeListener: vi.fn<() => void>(),
+      dispatchEvent: vi.fn<() => boolean>(),
+      media: '',
+      onchange: null
+    } as unknown as MediaQueryList);
+
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={[]}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    // Flush useEffect microtasks
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Advance past the 5 second inactivity timeout
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // After timeout, exit fullscreen button should be visible
+    await expect.element(screen.getByTestId('exit-fullscreen-button')).toBeInTheDocument();
+
+    // Click the exit fullscreen button
+    await screen.getByTestId('exit-fullscreen-button').click();
+
+    // Flush state updates
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Exit fullscreen button should be hidden again
+    expect(screen.container.querySelector('[data-testid="exit-fullscreen-button"]')).toBeNull();
+
+    // Footer should be revealed (data-controls-hidden should not be set)
+    expect(screen.container.querySelector('[data-controls-hidden]')).toBeNull();
+  });
 });
 
 function readDisplayedScore(

--- a/test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx
+++ b/test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx
@@ -791,23 +791,16 @@ describe('ActiveMatchScreen', () => {
 
   test('does not set data-controls-hidden when not in compact height', async () => {
     // Mock matchMedia to return false for max-height: 480px
-    const matchMediaMock = vi
-      .fn<
-        (query: string) => {
-          matches: boolean;
-          addEventListener: () => void;
-          removeEventListener: () => void;
-        }
-      >()
-      .mockReturnValue({
-        matches: false,
-        addEventListener: vi.fn<() => void>(),
-        removeEventListener: vi.fn<() => void>()
-      });
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: matchMediaMock
-    });
+    vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn<() => void>(),
+      removeEventListener: vi.fn<() => void>(),
+      addListener: vi.fn<() => void>(),
+      removeListener: vi.fn<() => void>(),
+      dispatchEvent: vi.fn<() => boolean>(),
+      media: '',
+      onchange: null
+    } as unknown as MediaQueryList);
 
     const screen = await render(
       <ActiveMatchScreen

--- a/test/hooks/useInactivityTimer.browser.test.tsx
+++ b/test/hooks/useInactivityTimer.browser.test.tsx
@@ -8,14 +8,12 @@ function InactivityTimerHarness({
   enabled = true,
   timeoutMs = 5000,
   ignoredTargetSelectors = [],
-  shouldIgnoreEvent,
-  _onStateChange
+  shouldIgnoreEvent
 }: {
   enabled?: boolean;
   timeoutMs?: number;
   ignoredTargetSelectors?: string[];
   shouldIgnoreEvent?: (event: Event) => boolean;
-  _onStateChange?: (isActive: boolean) => void;
 }) {
   const config: Parameters<typeof useInactivityTimer>[0] = {
     enabled,
@@ -117,7 +115,7 @@ describe('useInactivityTimer', () => {
       await expect.element(screen.getByTestId('is-active')).toHaveTextContent('true');
     });
 
-    test('starts inactive when enabled is false', async () => {
+    test('starts in active state when enabled is false', async () => {
       const screen = await render(<InactivityTimerHarness enabled={false} />);
 
       await expect.element(screen.getByTestId('is-active')).toHaveTextContent('true');

--- a/test/hooks/useInactivityTimer.browser.test.tsx
+++ b/test/hooks/useInactivityTimer.browser.test.tsx
@@ -1,0 +1,330 @@
+import { useState } from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, render } from 'vitest-browser-react';
+
+import { useInactivityTimer } from '@/hooks/useInactivityTimer';
+
+function InactivityTimerHarness({
+  enabled = true,
+  timeoutMs = 5000,
+  ignoredTargetSelectors = [],
+  shouldIgnoreEvent,
+  _onStateChange
+}: {
+  enabled?: boolean;
+  timeoutMs?: number;
+  ignoredTargetSelectors?: string[];
+  shouldIgnoreEvent?: (event: Event) => boolean;
+  _onStateChange?: (isActive: boolean) => void;
+}) {
+  const config: Parameters<typeof useInactivityTimer>[0] = {
+    enabled,
+    timeoutMs,
+    ignoredTargetSelectors
+  };
+
+  if (shouldIgnoreEvent !== undefined) {
+    config.shouldIgnoreEvent = shouldIgnoreEvent;
+  }
+
+  const { isActive } = useInactivityTimer(config);
+
+  return (
+    <div>
+      <span data-testid="is-active">{String(isActive)}</span>
+      <button
+        data-testid="ignored-button"
+        type="button"
+        onClick={() => {
+          /* No-op for testing */
+        }}
+      >
+        Ignored Button
+      </button>
+      <button
+        data-testid="regular-button"
+        type="button"
+        onClick={() => {
+          /* No-op for testing */
+        }}
+      >
+        Regular Button
+      </button>
+      <div
+        role="presentation"
+        data-testid="ignored-area"
+        style={{ padding: '10px' }}
+        onClick={() => {
+          /* No-op for testing */
+        }}
+      >
+        Ignored Area
+      </div>
+    </div>
+  );
+}
+
+// Predicate functions moved to outer scope to avoid recreating on every call
+function ignorePointerEventOnButton(event: Event): boolean {
+  if (event instanceof PointerEvent) {
+    return (event.target as HTMLElement)?.dataset?.testid === 'ignored-button';
+  }
+  return false;
+}
+
+function ignoreArrowLeftKey(event: Event): boolean {
+  if (event instanceof KeyboardEvent) {
+    return event.key === 'ArrowLeft';
+  }
+  return false;
+}
+
+/** Harness that toggles `enabled` via a button so we can test mid-lifecycle prop changes. */
+function ToggleEnabledHarness({ timeoutMs = 5000 }: { timeoutMs?: number }) {
+  const [enabled, setEnabled] = useState(true);
+  const { isActive } = useInactivityTimer({
+    enabled,
+    timeoutMs,
+    // Ignore pointerdown on the toggle button itself so clicking it doesn't reset the timer
+    ignoredTargetSelectors: ['[data-testid="toggle-enabled"]']
+  });
+
+  return (
+    <div>
+      <span data-testid="is-active">{String(isActive)}</span>
+      <button data-testid="toggle-enabled" type="button" onClick={() => setEnabled(false)}>
+        Disable
+      </button>
+    </div>
+  );
+}
+
+describe('useInactivityTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    await cleanup();
+  });
+
+  describe('initial state', () => {
+    test('starts in active state', async () => {
+      const screen = await render(<InactivityTimerHarness />);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('true');
+    });
+
+    test('starts inactive when enabled is false', async () => {
+      const screen = await render(<InactivityTimerHarness enabled={false} />);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('true');
+    });
+  });
+
+  describe('timeout expiry', () => {
+    test('transitions to inactive after timeout', async () => {
+      const screen = await render(<InactivityTimerHarness timeoutMs={5000} />);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('true');
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('false');
+    });
+
+    test('respects custom timeout value', async () => {
+      const screen = await render(<InactivityTimerHarness timeoutMs={3000} />);
+
+      await vi.advanceTimersByTimeAsync(3000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('false');
+    });
+  });
+
+  describe('reset on non-ignored interactions', () => {
+    test('resets timer on pointerdown on regular button', async () => {
+      const screen = await render(<InactivityTimerHarness timeoutMs={5000} />);
+
+      await vi.advanceTimersByTimeAsync(4000);
+
+      await screen.getByTestId('regular-button').click();
+
+      await vi.advanceTimersByTimeAsync(4000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('true');
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('false');
+    });
+
+    test('resets timer on pointerdown on document body', async () => {
+      const screen = await render(<InactivityTimerHarness timeoutMs={5000} />);
+
+      await vi.advanceTimersByTimeAsync(4000);
+
+      document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+
+      await vi.advanceTimersByTimeAsync(4000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('true');
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('false');
+    });
+
+    test('resets timer on keydown', async () => {
+      const screen = await render(<InactivityTimerHarness timeoutMs={5000} />);
+
+      await vi.advanceTimersByTimeAsync(4000);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+
+      await vi.advanceTimersByTimeAsync(4000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('true');
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('false');
+    });
+
+    test('resets timer on scroll', async () => {
+      const screen = await render(<InactivityTimerHarness timeoutMs={5000} />);
+
+      await vi.advanceTimersByTimeAsync(4000);
+
+      window.dispatchEvent(new Event('scroll', { bubbles: true }));
+
+      await vi.advanceTimersByTimeAsync(4000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('true');
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('false');
+    });
+  });
+
+  describe('ignore by selector', () => {
+    test('does not reset timer when clicking ignored button', async () => {
+      const screen = await render(
+        <InactivityTimerHarness
+          timeoutMs={5000}
+          ignoredTargetSelectors={['[data-testid="ignored-button"]']}
+        />
+      );
+
+      await vi.advanceTimersByTimeAsync(4000);
+
+      await screen.getByTestId('ignored-button').click();
+
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('false');
+    });
+
+    test('does not reset timer when clicking inside ignored area', async () => {
+      const screen = await render(
+        <InactivityTimerHarness
+          timeoutMs={5000}
+          ignoredTargetSelectors={['[data-testid="ignored-area"]']}
+        />
+      );
+
+      await vi.advanceTimersByTimeAsync(4000);
+
+      await screen.getByTestId('ignored-area').click();
+
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('false');
+    });
+
+    test('ignores pointerdown with shouldIgnoreEvent predicate', async () => {
+      const screen = await render(
+        <InactivityTimerHarness timeoutMs={5000} shouldIgnoreEvent={ignorePointerEventOnButton} />
+      );
+
+      await vi.advanceTimersByTimeAsync(4000);
+
+      await screen.getByTestId('ignored-button').click();
+
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('false');
+    });
+
+    test('ignores keydown with shouldIgnoreEvent predicate', async () => {
+      const screen = await render(
+        <InactivityTimerHarness timeoutMs={5000} shouldIgnoreEvent={ignoreArrowLeftKey} />
+      );
+
+      await vi.advanceTimersByTimeAsync(4000);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('false');
+    });
+  });
+
+  describe('disabled mode', () => {
+    test('returns permanently active state when disabled', async () => {
+      const screen = await render(<InactivityTimerHarness enabled={false} timeoutMs={1000} />);
+
+      await vi.advanceTimersByTimeAsync(10000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('true');
+    });
+
+    test('transitions to active when disabled mid-timeout', async () => {
+      const screen = await render(<ToggleEnabledHarness timeoutMs={5000} />);
+
+      await vi.advanceTimersByTimeAsync(3000);
+
+      // Toggle enabled → false via state change on the SAME component instance
+      await screen.getByTestId('toggle-enabled').click();
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      await expect.element(screen.getByTestId('is-active')).toHaveTextContent('true');
+    });
+  });
+
+  describe('cleanup', () => {
+    test('cleans up timers and listeners on unmount', async () => {
+      const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
+      const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener');
+
+      await render(<InactivityTimerHarness timeoutMs={5000} />);
+
+      const pointerDownHandlers = addEventListenerSpy.mock.calls.filter(
+        ([eventName]) => eventName === 'pointerdown'
+      );
+      const keyDownHandlers = addEventListenerSpy.mock.calls.filter(
+        ([eventName]) => eventName === 'keydown'
+      );
+
+      expect(pointerDownHandlers.length).toBeGreaterThan(0);
+      expect(keyDownHandlers.length).toBeGreaterThan(0);
+
+      await cleanup();
+
+      const pointerDownRemoveCalls = removeEventListenerSpy.mock.calls.filter(
+        ([eventName]) => eventName === 'pointerdown'
+      );
+      const keyDownRemoveCalls = removeEventListenerSpy.mock.calls.filter(
+        ([eventName]) => eventName === 'keydown'
+      );
+
+      expect(pointerDownRemoveCalls.length).toBeGreaterThan(0);
+      expect(keyDownRemoveCalls.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an inactivity-based UI affordance for compact-height mobile landscape where the footer automatically hides after a short period of inactivity while keeping the header visible. When controls are hidden the header shows an "Exit fullscreen" button which restores the footer and resets the inactivity timer.

## What was added

- `src/hooks/useInactivityTimer.ts` — new reusable hook that tracks user inactivity, supports ignored selectors and programmatic reset.
- `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx` — wire up compact-height detection and inactivity timer; pass `data-controls-hidden` prop to Layout root; display `Exit fullscreen` button in header.
- Tests:
  - `test/hooks/useInactivityTimer.browser.test.tsx` — browser tests validating timer behavior and ignored interactions.
  - `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx` — updated assertions for the new layout behavior and deterministic fake-timer handling.
- Docs:
  - `docs/plan/Plan PBW-97 Auto-hide header and footer in active match screen on mobile landscape.md`
  - `docs/plans/pbw-97-auto-hide-header-footer-plan.md`
- Minor CSS and i18n updates to support the new UI and strings.

## Behavior details

- In compact-height landscape (max-height: 480px), the inactivity timer (5s) runs when not in portrait.
- After the timeout, footer controls are hidden by setting `data-controls-hidden="true"` on the Layout root `<main>` element. The header remains visible and an "Exit fullscreen" button appears in the header.
- Clicking the "Exit fullscreen" button calls the hook's reset() and reveals the footer again.
- Score control interactions (team panel clicks and revert buttons) are intentionally ignored by the inactivity timer and do not reset the timer.

## Test results (local)

- Focused browser tests for ActiveMatchScreen pass locally.
- Full test suite passed in CI-like local run.

## Notes for reviewers

- The inactivity hook is designed to be reusable; it stores unstable config in refs to avoid restarting listeners on each render.
- The attribute `data-controls-hidden` is intentionally placed on the Layout `<main>` so it can be used by top-level CSS and transitions.