### PR TITLE
feat: redesign SetsCard and add sets history modal

### DIFF
--- a/docs/development-logs/Task PBW-102 Redesign Sets Card and Add Responsive Sets History Modal.md
+++ b/docs/development-logs/Task PBW-102 Redesign Sets Card and Add Responsive Sets History Modal.md
@@ -9,7 +9,7 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 ## Metadata
 
 - Task ID: PBW-102
-- Date (UTC): 2026-05-24T15:21:19Z
+- Date (UTC): 2026-05-24T15:51:42Z
 - Project: padelbuddy-web
 - Branch: feature/PBW-102-redesign-sets-card-and-add-responsive-sets-history-modal
 - Commit: d8d383c (staged changes awaiting commit)
@@ -26,15 +26,15 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 
 - **SetsCard redesign (PBW-111)**: Replaced the full set-grid card with a compact trigger showing only the current set score. Tapping the card opens the SetsHistoryModal. Removed scroll-based grid logic. Uses `getCurrentSet` / `getSetDisplayScore` helpers from `sets-history.ts`. Super-tiebreak display falls back to tiebreak points when individual game scores are not meaningful.
 
-- **SetsHistoryModal (PBW-110)**: New modal built on `@base-ui/react` dialog. Header displays overall sets-won score (e.g. "Sets 1 – 0") via `getSetsWonScore`. Body renders only completed sets — no in-progress set shown. Fixed focus management so dialog receives focus on open; fixed scroll containment so background does not scroll. 30-second auto-close timer with full state reset on close. Finish-navigation bypass suppresses auto-open when match-end transition is imminent. Super-tiebreak sets fall back to `tiebreakPoints` (with legacy `game.points` shape support).
+- **SetsHistoryModal (PBW-110)**: New modal built on `@base-ui/react` dialog. Header displays overall sets-won score (e.g. "Sets 1 – 0") via `getSetsWonScore`. i18n key renamed from `currentSetScoreHeadline` to `overallSetsScoreHeadline` to accurately reflect overall-sets-score semantics (not current-set score). Body renders only completed sets — no in-progress set shown. Fixed focus management so dialog receives focus on open; fixed scroll containment so background does not scroll. 30-second auto-close timer with full state reset on close. Finish-navigation bypass suppresses auto-open when match-end transition is imminent. Super-tiebreak sets fall back to `tiebreakPoints` (with legacy `game.points` shape support).
 
 - **Auto-open setup toggle**: New `autoOpenSetsHistoryModal` boolean added to `SetupFormData`, `MatchSetupInput`, `MatchSetup`, and `SetupPreferences`. Toggle exposed on SetupScreen UI. Value persists through `setup-storage.ts` (IndexedDB) with `true` as default for new installs. Parsing uses `typeof` guard for backward compatibility with stored records missing the field.
 
 - **Side-switch default change**: `sideSwitchPrompts` default changed from `true` to `false` in `defaultSetupPreferences`. Legacy matches (both in-progress and completed) without the field in their persisted record fall back to `true` via `shouldUseLegacySideSwitchPrompts` guard in `persistence.ts`, preserving existing behavior. Originally scoped to in-progress only (`shouldUseLegacyInProgressSideSwitchPrompts`); Copilot follow-up broadened the guard to cover completed records too — completed matches loaded for review/share also need the legacy fallback since they predate the field.
 
-- **E2E cold-start stabilization**: Refactored `match-flow.ts` helper — replaced single `setupReadyTimeoutMs` (15s) with per-attempt timeout (8s) + total budget (26s). Added `resetPersistence` option to clear IndexedDB before navigation. Added `autoOpenSetsHistoryModal` option to match-flow start-match API. Updated all 7 E2E specs to accommodate SetsCard UI changes and new setup fields.
+- **E2E cold-start stabilization**: Refactored `match-flow.ts` helper — replaced single `setupReadyTimeoutMs` (15s) with per-attempt timeout (8s) + total budget (26s). Added `resetPersistence` option to clear IndexedDB before navigation; `startMatch` now accepts optional `resetPersistence` override (defaults `true`) so callers can opt out of the reset when not needed. Added `autoOpenSetsHistoryModal` option to match-flow start-match API. Updated all 7 E2E specs to accommodate SetsCard UI changes and new setup fields.
 
-- **i18n**: Added translation keys for modal title, set history labels, and super-tiebreak badge across en, es, pt locales.
+- **i18n**: Added translation keys for modal title, set history labels, and super-tiebreak badge across en, es, pt locales. Headline key renamed to `overallSetsScoreHeadline` for semantic accuracy.
 
 ## Files Changed
 
@@ -42,7 +42,7 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 
 - `src/components/ActiveMatchScreen/SetsCard/SetsCard.tsx` — Compact current-score trigger with `onOpenHistory` callback
 - `src/components/ActiveMatchScreen/SetsCard/SetsCard.module.css` — Simplified styles for single-row card
-- `src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx` — New modal: Base UI dialog, overall header score, completed-set history only, auto-close timer
+- `src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx` — New modal: Base UI dialog, overall header score, completed-set history only, auto-close timer; i18n key renamed to `overallSetsScoreHeadline`
 - `src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.module.css` — Modal styles with responsive breakpoints
 - `src/components/ActiveMatchScreen/sets-history.ts` — Helpers: `getCurrentSet`, `getSetDisplayScore`, `getSetsWonScore`, `getSetsHistoryAutoOpenSignature`, super-tiebreak legacy score fallback
 - `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx` — Integrated SetsHistoryModal, auto-open hook, `autoOpenSetsHistoryModal` from match setup
@@ -63,9 +63,9 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 
 ### Localization
 
-- `src/lib/i18n/locales/en.ts` — English keys for sets history modal
-- `src/lib/i18n/locales/es.ts` — Spanish keys for sets history modal
-- `src/lib/i18n/locales/pt.ts` — Portuguese keys for sets history modal
+- `src/lib/i18n/locales/en.ts` — English keys for sets history modal; headline key renamed to `overallSetsScoreHeadline`
+- `src/lib/i18n/locales/es.ts` — Spanish keys for sets history modal; headline key renamed to `overallSetsScoreHeadline`
+- `src/lib/i18n/locales/pt.ts` — Portuguese keys for sets history modal; headline key renamed to `overallSetsScoreHeadline`
 
 ### Tests
 
@@ -82,7 +82,7 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 
 ### E2E
 
-- `e2e/helpers/match-flow.ts` — Refactored cold-start: per-attempt timeout + total budget, `resetPersistence`, `autoOpenSetsHistoryModal` option
+- `e2e/helpers/match-flow.ts` — Refactored cold-start: per-attempt timeout + total budget; `resetPersistence` as optional override in `startMatch` (defaults `true`); `autoOpenSetsHistoryModal` option
 - `e2e/active-match.happy-path.spec.ts` — Updated for SetsCard UI
 - `e2e/match-end.happy-path.spec.ts` — Updated for SetsCard UI
 - `e2e/tiebreaks.edge-case.spec.ts` — Updated for super-tiebreak display
@@ -99,7 +99,7 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 ## Key Decisions
 
 - **Base UI Dialog**: Chose `@base-ui/react` dialog for built-in a11y, focus trap, render-props API. Consistent with PBW-39 migration.
-- **Header shows overall sets score**: `getSetsWonScore` counts completed-set winners — gives immediate context without scanning rows.
+- **Header shows overall sets score**: `getSetsWonScore` counts completed-set winners — gives immediate context without scanning rows. i18n key `overallSetsScoreHeadline` renamed from `currentSetScoreHeadline` to avoid confusion with current-set score displayed on the card.
 - **Completed-set history only**: In-progress set excluded from modal body to avoid confusion between live score (card) and historical score (modal).
 - **Auto-open only on set completion**: Auto-open fires when the set-completion signature changes (`getSetsHistoryAutoOpenSignature`), not on every render. Prevents spurious opens.
 - **Auto-open setup toggle with persistence**: New field defaults `true` for new installs. Stored in IndexedDB via `setup-storage`. Parsing uses `typeof` guard for backward compat with records missing the field.
@@ -108,10 +108,11 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 - **Finish-navigation bypass**: Auto-open suppressed when match-end transition is imminent — prevents modal flash before screen change.
 - **Super-tiebreak legacy fallback**: `getCompletedSuperTiebreakScore` tries `tiebreakPoints` first, then legacy `game.points` shape, then falls back to `set.games`. Handles matches persisted before the tiebreakPoints field was added.
 - **E2E cold-start fix**: Replaced single 15s timeout with 8s per-attempt + 26s total budget in `match-flow.ts`. Reduces flaky failures on slow CI.
+- **E2E `startMatch` resetPersistence override**: `startMatch` accepts optional `resetPersistence` (defaults `true`). Lets callers skip IndexedDB clear when reusing existing state, without changing default behavior for existing specs.
 
 ## Validation Performed
 
-- `pnpm complete-check` — **PASSES** (lint, format, unit, browser, e2e all green) — re-verified after Copilot follow-up fix
+- `pnpm complete-check` — **PASSES** (lint, format, unit, browser, e2e all green) — re-verified after each Copilot follow-up
 - Code review — **APPROVED** (final review)
 - Architecture review — **APPROVED** (final architecture review)
 

--- a/docs/development-logs/Task PBW-102 Redesign Sets Card and Add Responsive Sets History Modal.md
+++ b/docs/development-logs/Task PBW-102 Redesign Sets Card and Add Responsive Sets History Modal.md
@@ -9,7 +9,7 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 ## Metadata
 
 - Task ID: PBW-102
-- Date (UTC): 2026-05-24T14:22:48Z
+- Date (UTC): 2026-05-24T15:21:19Z
 - Project: padelbuddy-web
 - Branch: feature/PBW-102-redesign-sets-card-and-add-responsive-sets-history-modal
 - Commit: d8d383c (staged changes awaiting commit)
@@ -30,7 +30,7 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 
 - **Auto-open setup toggle**: New `autoOpenSetsHistoryModal` boolean added to `SetupFormData`, `MatchSetupInput`, `MatchSetup`, and `SetupPreferences`. Toggle exposed on SetupScreen UI. Value persists through `setup-storage.ts` (IndexedDB) with `true` as default for new installs. Parsing uses `typeof` guard for backward compatibility with stored records missing the field.
 
-- **Side-switch default change**: `sideSwitchPrompts` default changed from `true` to `false` in `defaultSetupPreferences`. Legacy in-progress matches without the field in their persisted setup fall back to `true` via `shouldUseLegacyInProgressSideSwitchPrompts` guard in `persistence.ts`, preserving existing match behavior.
+- **Side-switch default change**: `sideSwitchPrompts` default changed from `true` to `false` in `defaultSetupPreferences`. Legacy matches (both in-progress and completed) without the field in their persisted record fall back to `true` via `shouldUseLegacySideSwitchPrompts` guard in `persistence.ts`, preserving existing behavior. Originally scoped to in-progress only (`shouldUseLegacyInProgressSideSwitchPrompts`); Copilot follow-up broadened the guard to cover completed records too — completed matches loaded for review/share also need the legacy fallback since they predate the field.
 
 - **E2E cold-start stabilization**: Refactored `match-flow.ts` helper — replaced single `setupReadyTimeoutMs` (15s) with per-attempt timeout (8s) + total budget (26s). Added `resetPersistence` option to clear IndexedDB before navigation. Added `autoOpenSetsHistoryModal` option to match-flow start-match API. Updated all 7 E2E specs to accommodate SetsCard UI changes and new setup fields.
 
@@ -59,7 +59,7 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 ### Persistence & Storage
 
 - `src/lib/setup/setup-storage.ts` — Added field to `SetupPreferences`, default `true`, `typeof` guard in parser for backward compat
-- `src/lib/current-match/persistence.ts` — Parse `autoOpenSetsHistoryModal` with fallback to `true`; `shouldUseLegacyInProgressSideSwitchPrompts` for `sideSwitchPrompts` backward compat
+- `src/lib/current-match/persistence.ts` — Parse `autoOpenSetsHistoryModal` with fallback to `true`; `shouldUseLegacySideSwitchPrompts` (broadened from in-progress-only to all records) for `sideSwitchPrompts` backward compat
 
 ### Localization
 
@@ -77,7 +77,7 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 - `test/components/SetupScreen/useSetupForm.browser.test.tsx` — Updated form tests
 - `test/components/SetupScreen/validateSetupForm.test.ts` — Validation test for new field
 - `test/current-match/indexed-db.browser.test.ts` — Updated persistence tests
-- `test/current-match/persistence.test.ts` — Tests for `autoOpenSetsHistoryModal` and legacy side-switch fallback
+- `test/current-match/persistence.test.ts` — Tests for `autoOpenSetsHistoryModal`, legacy in-progress side-switch fallback, and regression test for completed-record side-switch fallback
 - `test/lib/setup/setup-storage.test.ts` — Tests for new field storage and parsing
 
 ### E2E
@@ -103,7 +103,7 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 - **Completed-set history only**: In-progress set excluded from modal body to avoid confusion between live score (card) and historical score (modal).
 - **Auto-open only on set completion**: Auto-open fires when the set-completion signature changes (`getSetsHistoryAutoOpenSignature`), not on every render. Prevents spurious opens.
 - **Auto-open setup toggle with persistence**: New field defaults `true` for new installs. Stored in IndexedDB via `setup-storage`. Parsing uses `typeof` guard for backward compat with records missing the field.
-- **Side-switch default `false` for new setups**: Changed default in `defaultSetupPreferences`. Legacy in-progress matches without the field fall back to `true` via `shouldUseLegacyInProgressSideSwitchPrompts` guard in `persistence.ts`. No silent behavior change for existing matches.
+- **Side-switch default `false` for new setups**: Changed default in `defaultSetupPreferences`. Legacy matches (in-progress and completed) without the field fall back to `true` via `shouldUseLegacySideSwitchPrompts` guard in `persistence.ts`. Guard was initially scoped to in-progress only; Copilot follow-up broadened it to completed records too since completed matches loaded for review/share also predate the field. No silent behavior change for any existing matches.
 - **30-second auto-close with full reset**: Timer-based close avoids modal hanging. State fully resets (no memory leaks, no stale timers).
 - **Finish-navigation bypass**: Auto-open suppressed when match-end transition is imminent — prevents modal flash before screen change.
 - **Super-tiebreak legacy fallback**: `getCompletedSuperTiebreakScore` tries `tiebreakPoints` first, then legacy `game.points` shape, then falls back to `set.games`. Handles matches persisted before the tiebreakPoints field was added.
@@ -111,7 +111,7 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 
 ## Validation Performed
 
-- `pnpm complete-check` — **PASSES** (lint, format, unit, browser, e2e all green)
+- `pnpm complete-check` — **PASSES** (lint, format, unit, browser, e2e all green) — re-verified after Copilot follow-up fix
 - Code review — **APPROVED** (final review)
 - Architecture review — **APPROVED** (final architecture review)
 
@@ -121,3 +121,4 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 - Super-tiebreak display uses score fallback; a point-by-point visualization could be a future enhancement.
 - E2E does not explicitly test the 30-second auto-close timer (timing-dependent tests are fragile); browser tests cover the close logic.
 - Legacy super-tiebreak shape fallback can be removed once all pre-tiebreakPoints matches have expired from user devices.
+- Legacy `sideSwitchPrompts` fallback (broadened to all records) can be removed once all pre-field matches have expired from user devices.

--- a/docs/development-logs/Task PBW-102 Redesign Sets Card and Add Responsive Sets History Modal.md
+++ b/docs/development-logs/Task PBW-102 Redesign Sets Card and Add Responsive Sets History Modal.md
@@ -1,0 +1,123 @@
+---
+title: PBW-102 Redesign Sets Card and Add Responsive Sets History Modal
+type: development-log
+permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-responsive-sets-history-modal
+---
+
+# Development Log: PBW-102
+
+## Metadata
+
+- Task ID: PBW-102
+- Date (UTC): 2026-05-24T14:22:48Z
+- Project: padelbuddy-web
+- Branch: feature/PBW-102-redesign-sets-card-and-add-responsive-sets-history-modal
+- Commit: d8d383c (staged changes awaiting commit)
+- Sub-issues: PBW-111 (SetsCard redesign), PBW-110 (SetsHistoryModal), PBW-109 (auto-open/close logic)
+
+## Objective
+
+- Redesign SetsCard to show only the current-set score as a compact trigger.
+- Build a responsive SetsHistoryModal (Base UI dialog) that displays overall sets score in the header and completed-set history only.
+- Add a setup-screen toggle for auto-open behavior that persists via IndexedDB.
+- Stabilize E2E cold-start specs and fix modal focus/scroll issues.
+
+## Implementation Summary
+
+- **SetsCard redesign (PBW-111)**: Replaced the full set-grid card with a compact trigger showing only the current set score. Tapping the card opens the SetsHistoryModal. Removed scroll-based grid logic. Uses `getCurrentSet` / `getSetDisplayScore` helpers from `sets-history.ts`. Super-tiebreak display falls back to tiebreak points when individual game scores are not meaningful.
+
+- **SetsHistoryModal (PBW-110)**: New modal built on `@base-ui/react` dialog. Header displays overall sets-won score (e.g. "Sets 1 – 0") via `getSetsWonScore`. Body renders only completed sets — no in-progress set shown. Fixed focus management so dialog receives focus on open; fixed scroll containment so background does not scroll. 30-second auto-close timer with full state reset on close. Finish-navigation bypass suppresses auto-open when match-end transition is imminent. Super-tiebreak sets fall back to `tiebreakPoints` (with legacy `game.points` shape support).
+
+- **Auto-open setup toggle**: New `autoOpenSetsHistoryModal` boolean added to `SetupFormData`, `MatchSetupInput`, `MatchSetup`, and `SetupPreferences`. Toggle exposed on SetupScreen UI. Value persists through `setup-storage.ts` (IndexedDB) with `true` as default for new installs. Parsing uses `typeof` guard for backward compatibility with stored records missing the field.
+
+- **Side-switch default change**: `sideSwitchPrompts` default changed from `true` to `false` in `defaultSetupPreferences`. Legacy in-progress matches without the field in their persisted setup fall back to `true` via `shouldUseLegacyInProgressSideSwitchPrompts` guard in `persistence.ts`, preserving existing match behavior.
+
+- **E2E cold-start stabilization**: Refactored `match-flow.ts` helper — replaced single `setupReadyTimeoutMs` (15s) with per-attempt timeout (8s) + total budget (26s). Added `resetPersistence` option to clear IndexedDB before navigation. Added `autoOpenSetsHistoryModal` option to match-flow start-match API. Updated all 7 E2E specs to accommodate SetsCard UI changes and new setup fields.
+
+- **i18n**: Added translation keys for modal title, set history labels, and super-tiebreak badge across en, es, pt locales.
+
+## Files Changed
+
+### Core Components
+
+- `src/components/ActiveMatchScreen/SetsCard/SetsCard.tsx` — Compact current-score trigger with `onOpenHistory` callback
+- `src/components/ActiveMatchScreen/SetsCard/SetsCard.module.css` — Simplified styles for single-row card
+- `src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx` — New modal: Base UI dialog, overall header score, completed-set history only, auto-close timer
+- `src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.module.css` — Modal styles with responsive breakpoints
+- `src/components/ActiveMatchScreen/sets-history.ts` — Helpers: `getCurrentSet`, `getSetDisplayScore`, `getSetsWonScore`, `getSetsHistoryAutoOpenSignature`, super-tiebreak legacy score fallback
+- `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx` — Integrated SetsHistoryModal, auto-open hook, `autoOpenSetsHistoryModal` from match setup
+- `src/components/ActiveMatchScreen/ActiveMatchScreen.module.css` — Layout adjustments for modal integration
+
+### Setup Screen & Match Types
+
+- `src/components/SetupScreen/SetupScreen.tsx` — Added auto-open toggle UI control
+- `src/components/SetupScreen/types.ts` — Added `autoOpenSetsHistoryModal` to `SetupFormData`
+- `src/components/SetupScreen/useSetupForm.ts` — Toggle state management in setup form
+- `src/core/match/types.ts` — Added `autoOpenSetsHistoryModal` to `MatchSetupInput` (optional) and `MatchSetup` (required)
+- `src/core/match/validation.ts` — Validation for new field
+
+### Persistence & Storage
+
+- `src/lib/setup/setup-storage.ts` — Added field to `SetupPreferences`, default `true`, `typeof` guard in parser for backward compat
+- `src/lib/current-match/persistence.ts` — Parse `autoOpenSetsHistoryModal` with fallback to `true`; `shouldUseLegacyInProgressSideSwitchPrompts` for `sideSwitchPrompts` backward compat
+
+### Localization
+
+- `src/lib/i18n/locales/en.ts` — English keys for sets history modal
+- `src/lib/i18n/locales/es.ts` — Spanish keys for sets history modal
+- `src/lib/i18n/locales/pt.ts` — Portuguese keys for sets history modal
+
+### Tests
+
+- `test/components/ActiveMatchScreen/SetsCard.browser.test.tsx` — Updated for compact card layout
+- `test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx` — New modal browser tests
+- `test/components/ActiveMatchScreen/sets-history.test.ts` — Unit tests for all sets-history helpers
+- `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx` — Updated integration tests
+- `test/components/SetupScreen/SetupScreen.browser.test.tsx` — Tests for auto-open toggle
+- `test/components/SetupScreen/useSetupForm.browser.test.tsx` — Updated form tests
+- `test/components/SetupScreen/validateSetupForm.test.ts` — Validation test for new field
+- `test/current-match/indexed-db.browser.test.ts` — Updated persistence tests
+- `test/current-match/persistence.test.ts` — Tests for `autoOpenSetsHistoryModal` and legacy side-switch fallback
+- `test/lib/setup/setup-storage.test.ts` — Tests for new field storage and parsing
+
+### E2E
+
+- `e2e/helpers/match-flow.ts` — Refactored cold-start: per-attempt timeout + total budget, `resetPersistence`, `autoOpenSetsHistoryModal` option
+- `e2e/active-match.happy-path.spec.ts` — Updated for SetsCard UI
+- `e2e/match-end.happy-path.spec.ts` — Updated for SetsCard UI
+- `e2e/tiebreaks.edge-case.spec.ts` — Updated for super-tiebreak display
+- `e2e/undo.edge-case.spec.ts` — Updated for SetsCard interactions
+- `e2e/persistence-recovery.edge-case.spec.ts` — Updated for SetsCard state
+- `e2e/golden-point.edge-case.spec.ts` — Updated for SetsCard display
+- `e2e/advantage-deuce.edge-case.spec.ts` — Updated for SetsCard display
+- `e2e/responsive-layout.spec.ts` — Updated for responsive modal layout
+
+### Documentation
+
+- `docs/plan/Plan PBW-102 Redesign sets card and add responsive sets history modal.md` — Implementation plan
+
+## Key Decisions
+
+- **Base UI Dialog**: Chose `@base-ui/react` dialog for built-in a11y, focus trap, render-props API. Consistent with PBW-39 migration.
+- **Header shows overall sets score**: `getSetsWonScore` counts completed-set winners — gives immediate context without scanning rows.
+- **Completed-set history only**: In-progress set excluded from modal body to avoid confusion between live score (card) and historical score (modal).
+- **Auto-open only on set completion**: Auto-open fires when the set-completion signature changes (`getSetsHistoryAutoOpenSignature`), not on every render. Prevents spurious opens.
+- **Auto-open setup toggle with persistence**: New field defaults `true` for new installs. Stored in IndexedDB via `setup-storage`. Parsing uses `typeof` guard for backward compat with records missing the field.
+- **Side-switch default `false` for new setups**: Changed default in `defaultSetupPreferences`. Legacy in-progress matches without the field fall back to `true` via `shouldUseLegacyInProgressSideSwitchPrompts` guard in `persistence.ts`. No silent behavior change for existing matches.
+- **30-second auto-close with full reset**: Timer-based close avoids modal hanging. State fully resets (no memory leaks, no stale timers).
+- **Finish-navigation bypass**: Auto-open suppressed when match-end transition is imminent — prevents modal flash before screen change.
+- **Super-tiebreak legacy fallback**: `getCompletedSuperTiebreakScore` tries `tiebreakPoints` first, then legacy `game.points` shape, then falls back to `set.games`. Handles matches persisted before the tiebreakPoints field was added.
+- **E2E cold-start fix**: Replaced single 15s timeout with 8s per-attempt + 26s total budget in `match-flow.ts`. Reduces flaky failures on slow CI.
+
+## Validation Performed
+
+- `pnpm complete-check` — **PASSES** (lint, format, unit, browser, e2e all green)
+- Code review — **APPROVED** (final review)
+- Architecture review — **APPROVED** (final architecture review)
+
+## Risks and Follow-ups
+
+- Auto-open timing may need tuning if users report intrusiveness during rapid set transitions.
+- Super-tiebreak display uses score fallback; a point-by-point visualization could be a future enhancement.
+- E2E does not explicitly test the 30-second auto-close timer (timing-dependent tests are fragile); browser tests cover the close logic.
+- Legacy super-tiebreak shape fallback can be removed once all pre-tiebreakPoints matches have expired from user devices.

--- a/docs/development-logs/Task PBW-102 Redesign Sets Card and Add Responsive Sets History Modal.md
+++ b/docs/development-logs/Task PBW-102 Redesign Sets Card and Add Responsive Sets History Modal.md
@@ -9,7 +9,7 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 ## Metadata
 
 - Task ID: PBW-102
-- Date (UTC): 2026-05-24T15:51:42Z
+- Date (UTC): 2026-05-24T16:10:45Z
 - Project: padelbuddy-web
 - Branch: feature/PBW-102-redesign-sets-card-and-add-responsive-sets-history-modal
 - Commit: d8d383c (staged changes awaiting commit)
@@ -24,7 +24,7 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 
 ## Implementation Summary
 
-- **SetsCard redesign (PBW-111)**: Replaced the full set-grid card with a compact trigger showing only the current set score. Tapping the card opens the SetsHistoryModal. Removed scroll-based grid logic. Uses `getCurrentSet` / `getSetDisplayScore` helpers from `sets-history.ts`. Super-tiebreak display falls back to tiebreak points when individual game scores are not meaningful.
+- **SetsCard redesign (PBW-111)**: Replaced the full set-grid card with a compact trigger showing only the current set score. Tapping the card opens the SetsHistoryModal. Removed scroll-based grid logic. Uses `getCurrentSet` / `getSetDisplayScore` helpers from `sets-history.ts`. Super-tiebreak display falls back to tiebreak points when individual game scores are not meaningful. SetsCard aria label (`openHistoryLabel`) describes current-set score semantics; ES/PT translations corrected to say "Marcador del set actual" / "Placar do set atual" (not "sets" overall).
 
 - **SetsHistoryModal (PBW-110)**: New modal built on `@base-ui/react` dialog. Header displays overall sets-won score (e.g. "Sets 1 – 0") via `getSetsWonScore`. i18n key renamed from `currentSetScoreHeadline` to `overallSetsScoreHeadline` to accurately reflect overall-sets-score semantics (not current-set score). Body renders only completed sets — no in-progress set shown. Fixed focus management so dialog receives focus on open; fixed scroll containment so background does not scroll. 30-second auto-close timer with full state reset on close. Finish-navigation bypass suppresses auto-open when match-end transition is imminent. Super-tiebreak sets fall back to `tiebreakPoints` (with legacy `game.points` shape support).
 
@@ -34,7 +34,7 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 
 - **E2E cold-start stabilization**: Refactored `match-flow.ts` helper — replaced single `setupReadyTimeoutMs` (15s) with per-attempt timeout (8s) + total budget (26s). Added `resetPersistence` option to clear IndexedDB before navigation; `startMatch` now accepts optional `resetPersistence` override (defaults `true`) so callers can opt out of the reset when not needed. Added `autoOpenSetsHistoryModal` option to match-flow start-match API. Updated all 7 E2E specs to accommodate SetsCard UI changes and new setup fields.
 
-- **i18n**: Added translation keys for modal title, set history labels, and super-tiebreak badge across en, es, pt locales. Headline key renamed to `overallSetsScoreHeadline` for semantic accuracy.
+- **i18n**: Added translation keys for modal title, set history labels, and super-tiebreak badge across en, es, pt locales. Headline key renamed to `overallSetsScoreHeadline` for semantic accuracy. ES/PT `openHistoryLabel` wording corrected from "Marcador de sets" / "Placar de sets" to "Marcador del set actual" / "Placar do set atual" — the aria label describes the card's current-set score, not the overall sets score.
 
 ## Files Changed
 
@@ -64,13 +64,13 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 ### Localization
 
 - `src/lib/i18n/locales/en.ts` — English keys for sets history modal; headline key renamed to `overallSetsScoreHeadline`
-- `src/lib/i18n/locales/es.ts` — Spanish keys for sets history modal; headline key renamed to `overallSetsScoreHeadline`
-- `src/lib/i18n/locales/pt.ts` — Portuguese keys for sets history modal; headline key renamed to `overallSetsScoreHeadline`
+- `src/lib/i18n/locales/es.ts` — Spanish keys; headline key renamed to `overallSetsScoreHeadline`; `openHistoryLabel` corrected to current-set semantics ("Marcador del set actual")
+- `src/lib/i18n/locales/pt.ts` — Portuguese keys; headline key renamed to `overallSetsScoreHeadline`; `openHistoryLabel` corrected to current-set semantics ("Placar do set atual")
 
 ### Tests
 
 - `test/components/ActiveMatchScreen/SetsCard.browser.test.tsx` — Updated for compact card layout
-- `test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx` — New modal browser tests
+- `test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx` — New modal browser tests; `afterEach` restores real timers (`vi.useRealTimers()`) to prevent fake-timer leakage across tests
 - `test/components/ActiveMatchScreen/sets-history.test.ts` — Unit tests for all sets-history helpers
 - `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx` — Updated integration tests
 - `test/components/SetupScreen/SetupScreen.browser.test.tsx` — Tests for auto-open toggle
@@ -100,6 +100,7 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 
 - **Base UI Dialog**: Chose `@base-ui/react` dialog for built-in a11y, focus trap, render-props API. Consistent with PBW-39 migration.
 - **Header shows overall sets score**: `getSetsWonScore` counts completed-set winners — gives immediate context without scanning rows. i18n key `overallSetsScoreHeadline` renamed from `currentSetScoreHeadline` to avoid confusion with current-set score displayed on the card.
+- **SetsCard aria label = current-set semantics**: The card's `openHistoryLabel` aria label describes the score shown on the card (current set), not the overall sets score. ES/PT translations corrected to match.
 - **Completed-set history only**: In-progress set excluded from modal body to avoid confusion between live score (card) and historical score (modal).
 - **Auto-open only on set completion**: Auto-open fires when the set-completion signature changes (`getSetsHistoryAutoOpenSignature`), not on every render. Prevents spurious opens.
 - **Auto-open setup toggle with persistence**: New field defaults `true` for new installs. Stored in IndexedDB via `setup-storage`. Parsing uses `typeof` guard for backward compat with records missing the field.
@@ -109,6 +110,7 @@ permalink: docs/development-logs/task-PBW-102-redesign-sets-card-and-add-respons
 - **Super-tiebreak legacy fallback**: `getCompletedSuperTiebreakScore` tries `tiebreakPoints` first, then legacy `game.points` shape, then falls back to `set.games`. Handles matches persisted before the tiebreakPoints field was added.
 - **E2E cold-start fix**: Replaced single 15s timeout with 8s per-attempt + 26s total budget in `match-flow.ts`. Reduces flaky failures on slow CI.
 - **E2E `startMatch` resetPersistence override**: `startMatch` accepts optional `resetPersistence` (defaults `true`). Lets callers skip IndexedDB clear when reusing existing state, without changing default behavior for existing specs.
+- **Browser test timer hygiene**: SetsHistoryModal browser tests use `vi.useFakeTimers()` for auto-close assertions; `afterEach` calls `vi.useRealTimers()` to prevent fake-timer leakage into subsequent tests.
 
 ## Validation Performed
 

--- a/docs/plan/Plan PBW-102 Redesign sets card and add responsive sets history modal.md
+++ b/docs/plan/Plan PBW-102 Redesign sets card and add responsive sets history modal.md
@@ -1,0 +1,229 @@
+## Task Analysis
+
+- Main objective:
+  - Deliver PBW-102 as a 3-part implementation on current branch:
+    - `PBW-111` redesign `SetsCard` so active match screen shows only the current set score with larger, simpler presentation.
+    - `PBW-110` add a responsive sets-history modal that can be opened from the card at any time during an active match.
+    - `PBW-109` wire auto-open + 30-second auto-close + retrigger reset behavior, while preserving immediate finish-screen navigation when the match ends.
+  - Understanding summary:
+    - Current `SetsCard` renders every set in a reverse-scrolling list; target UI reduces that surface to current set score only.
+    - Modal must show live current-set headline plus all set scores, including super-tiebreak points where relevant.
+    - Auto-open must happen only when the set score changes because a game or set completed, not on ordinary points and not on intermediate tiebreak-point updates.
+    - Manual open and auto-open share the same 30-second close behavior.
+    - Reopening while already visible must refresh content and restart the timer.
+    - Final match completion must keep existing immediate route handoff to `/match/finish/$id` with no modal delay.
+    - Scope stays inside active-match UI/i18n/tests; no scoring-rule or persistence redesign expected.
+- Identified dependencies:
+  - Active match composition and state flow:
+    - `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx`
+    - `src/components/ActiveMatchScreen/ActiveMatchScreen.module.css`
+    - `src/components/ActiveMatchScreen/useMatchSession.ts`
+  - Existing sets card and tests:
+    - `src/components/ActiveMatchScreen/SetsCard/SetsCard.tsx`
+    - `src/components/ActiveMatchScreen/SetsCard/SetsCard.module.css`
+    - `test/components/ActiveMatchScreen/SetsCard.browser.test.tsx`
+  - Modal/accessibility precedent:
+    - `src/components/ActiveMatchScreen/SideSwitchPrompt/SideSwitchPrompt.tsx`
+    - `src/components/ActiveMatchScreen/SideSwitchPrompt/SideSwitchPrompt.module.css`
+    - `src/components/SetupScreen/RemoteConfigurationModal.tsx`
+    - `src/styles/shared-setup-modal.module.css`
+    - `src/styles/shared-overlays.module.css`
+  - Domain data needed for correct score display:
+    - `src/core/match/types.ts`
+    - `src/core/match/derived-state.ts`
+    - `src/core/match/engine.ts`
+    - `src/components/MatchEndScreen/view-model.ts`
+    - `src/components/HistoryScreen/HistoryScreen.tsx`
+  - Locales and QA:
+    - `src/lib/i18n/locales/en.ts`
+    - `src/lib/i18n/locales/es.ts`
+    - `src/lib/i18n/locales/pt.ts`
+    - `test/components/ActiveMatchScreen/SideSwitchPrompt.browser.test.tsx`
+    - `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx`
+    - `docs/design/padelbuddyweb.pen`
+    - `design-tokens/**/*`
+- System impact:
+  - Expected impact stays screen-local: one existing overlay card becomes an interactive trigger, one new modal component is introduced, and `ActiveMatchScreen` gains small UI state/effect logic for open/close automation.
+  - No new global store, no route changes, no IndexedDB/schema changes, no match-engine rule changes should be required if implementation stays at the projection/UI layer.
+  - Assumptions made:
+    - Provided approved sub-issues already satisfy planning split; no additional Linear dependency gate remains for this delivery plan.
+    - Existing Base UI Dialog pattern is approved for reuse here.
+    - Browser tests are acceptable for modal timing assertions; Playwright is optional, not mandatory, unless browser timers prove unreliable.
+    - Current design tokens are sufficient; if Pencil review exposes a missing token, prefer existing generated variables over introducing raw values.
+  - Main risks:
+    - Auto-open false positives on tiebreak points or undo flows.
+    - Timer not restarting when user reopens modal while it is already open.
+    - Super-tiebreak score rendering drifting between card, modal, history, and match-end conventions.
+    - Finish-route navigation racing against modal open on the last scoring action.
+  - Plan file:
+    - `/Users/trystan2k/Documents/Thiago/Repos/padelbuddy-web/docs/plan/Plan PBW-102 Redesign sets card and add responsive sets history modal.md`
+
+## Chosen Approach
+
+- Proposed solution:
+  - Keep all new behavior in `ActiveMatchScreen` layer, not in session/domain layers.
+  - Implement a dedicated `SetsHistoryModal` component beside the existing `SetsCard`, using Base UI Dialog plus shared overlay/modal styling patterns already used elsewhere.
+  - Convert `SetsCard` into a lightweight trigger surface that displays only current-set score data and delegates modal opening through an `onOpenHistory` callback.
+  - Add one tiny local helper for set-score formatting/signature generation so the card, modal, and auto-open effect use one consistent interpretation of:
+    - active standard set = games
+    - active super-tiebreak set = tiebreak points
+    - completed super-tiebreak set = stored `tiebreakPoints`
+  - Detect auto-open from snapshot diffs in `ActiveMatchScreen`: compare previous vs current set-progression signature and only open when a scoring action advanced set history in a meaningful way and the match is still not completed.
+  - Use an `openToken`/nonce prop so both manual reopen and auto-retrigger refresh modal content and restart the shared 30-second timer without adding global timer state.
+- Justification for simplicity:
+  - Recommended approach:
+    - Reuses existing `useMatchSession` output and `snapshot.projection` data instead of inventing new event APIs.
+    - Contains new UI behavior to one screen and two focused components.
+    - Reuses Base UI dialog + shared overlay/modal CSS patterns already proven in repo.
+  - Rejected approach 1:
+    - Extend `useMatchSession` to emit rich scoring events like `game-won`, `set-won`, `match-won`.
+    - Rejected because only `ActiveMatchScreen` consumes the hook today; snapshot diffing is cheaper and avoids widening hook API/test surface.
+  - Rejected approach 2:
+    - Generalize `SideSwitchPrompt` into a generic active-match modal framework.
+    - Rejected because this feature only needs one new dialog shape; abstraction now would add prop complexity with little reuse.
+  - Rejected approach 3:
+    - Derive auto-open directly from visible score strings in the modal/card.
+    - Rejected because active super-tiebreak points would trigger on every point; trigger logic must key off set progression, not every visual number change.
+  - Decision log:
+    - Use screen-local state, not global/session state.
+    - Use dedicated `SetsHistoryModal`, not a generic modal abstraction.
+    - Use native trigger semantics for `SetsCard` instead of expanding shared `Card` API.
+    - Use `openToken` reset pattern for timer restarts.
+    - Use projection-diff trigger logic filtered to scoring progression and non-completed matches.
+- Components to be modified/created:
+  - `PBW-111`:
+    - Modify `src/components/ActiveMatchScreen/SetsCard/SetsCard.tsx`
+    - Modify `src/components/ActiveMatchScreen/SetsCard/SetsCard.module.css`
+    - Likely add small local helper such as `src/components/ActiveMatchScreen/sets-history.ts` for shared display/trigger logic
+    - Update `test/components/ActiveMatchScreen/SetsCard.browser.test.tsx`
+  - `PBW-110`:
+    - Create `src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx`
+    - Create `src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.module.css`
+    - Modify `src/lib/i18n/locales/en.ts`
+    - Modify `src/lib/i18n/locales/es.ts`
+    - Modify `src/lib/i18n/locales/pt.ts`
+    - Add focused browser coverage, preferably `test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx`
+  - `PBW-109`:
+    - Modify `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx`
+    - Modify `src/components/ActiveMatchScreen/ActiveMatchScreen.module.css` only if modal trigger placement/overlay interaction needs it
+    - Keep `src/components/ActiveMatchScreen/useMatchSession.ts` unchanged unless implementation proves snapshot diffing insufficient
+    - Update `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx`
+
+## Implementation Steps
+
+1. `PBW-111` — redesign `SetsCard` to current-set-only trigger.
+   - Pre-implementation check:
+     - Verify Pencil node/state for the active sets card in `docs/design/padelbuddyweb.pen` and confirm whether the label remains visible or the card is score-only.
+     - Confirm current tokenized width/typography values in `SetsCard.module.css` and matching generated CSS variables.
+   - Refactor `SetsCard` API from passive renderer to focused active-set display:
+     - Add an `onOpenHistory` callback.
+     - Derive a single current-set row/value instead of mapping every set.
+     - Preserve stable test ids while introducing trigger semantics (`button` or button-like root) so the whole card is clickable.
+   - Keep the component visually simple:
+     - one-line current set score
+     - larger typography than current multi-row list
+     - no scrolling container or reverse list behavior
+   - Use shared helper logic for score extraction so active super-tiebreak sets show points, not `0-0` games.
+   - Update `SetsCard` browser tests to assert:
+     - only current set content renders
+     - completed-set list is no longer present in card body
+     - trigger/button semantics exist
+     - current super-tiebreak display uses points when relevant
+   - Risk/mitigation:
+     - `Card` is a `div`, not an interactive primitive. Prefer a native button-styled root or a reset button wrapper around the card visuals rather than broadening shared `Card` API for one screen.
+
+2. `PBW-110` — create responsive `SetsHistoryModal`.
+   - Build a dedicated dialog component using Base UI `Dialog.Root/Portal/Backdrop/Popup` following `SideSwitchPrompt` and setup modal patterns.
+   - Keep content minimal and task-aligned:
+     - close icon button in top-right using existing `common.close` aria label pattern
+     - headline `Current set score: X - Y`
+     - full set history list below using existing `match.sets.setLabel` copy where possible
+     - super-tiebreak rows/headline show points when the set is a super-tiebreak
+   - Reuse existing shared overlay/modal CSS patterns:
+     - shared backdrop from `shared-overlays.module.css`
+     - modal shell sizing/scroll constraints from `shared-setup-modal.module.css`
+     - local CSS module only for header, close button, score list, and responsive spacing/type adjustments
+   - Add only necessary i18n keys in `en/es/pt` for modal-specific copy; reuse `match.sets.label`, `match.sets.setLabel`, `match.sets.superTiebreakBadge`, and `common.close` wherever possible.
+   - Add focused modal tests for:
+     - render/open state
+     - headline score content
+     - list of all set scores
+     - close button accessibility + close action
+     - responsive-safe structure assumptions (dialog role, aria-modal, scrollable container)
+   - Risk/mitigation:
+     - Do not fork a new generic modal style system. Compose existing shared modal rules and keep new CSS local so visual risk stays bounded.
+
+3. `PBW-109` — wire open behavior, timer lifecycle, match-end bypass, and regression tests.
+   - Add local state in `ActiveMatchScreen` for:
+     - `isSetsHistoryOpen`
+     - `setsHistoryOpenToken` or equivalent nonce to restart timer/content on repeated opens
+   - Add a previous-snapshot ref and a small trigger-signature helper.
+     - Signature should change for:
+       - completed-set additions/score finalization
+       - active standard-set game-count changes
+     - Signature should not change for:
+       - ordinary standard-game points
+       - intermediate tiebreak points in a standard tiebreak
+       - intermediate points in an in-progress super-tiebreak set
+       - undo-only flows
+   - Implement manual open path from `SetsCard`:
+     - open modal anytime while match remains in progress
+     - if modal already open, increment token so timer restarts and any new score snapshot is reflected immediately
+   - Implement shared 30-second auto-close in modal effect keyed by `isOpen + openToken`.
+   - Implement auto-open effect in `ActiveMatchScreen`:
+     - compare previous/current signatures after scoring actions
+     - skip when match has just completed or is already navigating to finish
+     - skip when change came from undo or no-op scoring
+   - Preserve existing finish behavior:
+     - existing navigate-on-complete effect remains authoritative
+     - last-point match completion must navigate immediately and never wait for modal timeout
+   - Expand `ActiveMatchScreen` browser coverage for:
+     - manual open from sets card
+     - auto-open after game completion
+     - no auto-open on regular point increments
+     - no auto-open on intermediate tiebreak points
+     - timer auto-close after 30 seconds
+     - reopen/retrigger resets timer
+     - completed-match scoring path navigates immediately without modal wait
+   - Rollback note:
+     - If auto-open diff logic becomes noisy, keep modal manual-open only first, then refine signature logic before shipping. Do not move the logic into the domain/session layer as a first rescue step.
+
+## Validation
+
+- Success criteria:
+  - `SetsCard` shows only the active set score in simplified one-line presentation with larger typography aligned to Pencil/tokens.
+  - The sets card acts as an accessible trigger and opens the sets-history modal during any in-progress match state.
+  - Modal headline shows `Current set score: X - Y` and uses super-tiebreak points when the current set is a super-tiebreak.
+  - Modal lists all set scores accurately, including completed super-tiebreak sets.
+  - Modal includes a top-right close icon/button with correct accessibility labeling.
+  - Auto-open fires only after scoring progression that changes set history meaningfully (game/set completion), not after ordinary point updates or intermediate tiebreak points.
+  - Manual open and auto-open both auto-close after 30 seconds.
+  - Reopen/retrigger while visible refreshes content and restarts the countdown.
+  - Final match completion still navigates immediately to finish screen without modal delay.
+  - Mobile, tablet, and desktop layouts remain usable, scroll-safe, and visually aligned with design tokens/Pencil intent.
+  - `pnpm complete-check` passes with no coverage-threshold changes.
+- Checkpoints:
+  - Assumptions check before code:
+    - confirm exact Pencil copy/layout expectations for whether `Sets` label remains on card and whether modal needs an additional section title beyond the required headline
+    - confirm no hidden dependency in Linear beyond provided split
+  - After `PBW-111`:
+    - `test/components/ActiveMatchScreen/SetsCard.browser.test.tsx` passes and proves current-set-only rendering + trigger semantics.
+    - Manual visual check against Pencil for score scale, spacing, and clickable affordance.
+  - After `PBW-110`:
+    - modal unit/browser coverage passes for render, close icon, list content, and super-tiebreak score formatting.
+    - Manual responsive QA at phone, tablet, desktop widths confirms popup stays within viewport and scrolls internally if needed.
+  - After `PBW-109`:
+    - `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx` proves manual open, timed close, timer reset, game/set auto-open, tiebreak non-trigger, and finish-route bypass.
+    - Regression check confirms existing side-switch prompt and finish navigation behavior stay green.
+  - Final QA strategy:
+    - Run targeted suites first:
+      - `test/components/ActiveMatchScreen/SetsCard.browser.test.tsx`
+      - `test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx` if created
+      - `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx`
+    - Then run `pnpm complete-check`.
+    - Manual QA pass on active match screen for desktop + tablet + mobile landscape, plus final-point finish flow.
+  - Risks and mitigations:
+    - False auto-open on wrong state transitions -> base trigger on explicit progression signature and scoring-action direction.
+    - Timer not resetting on repeated opens -> key timer effect on `openToken`, not boolean-only state.
+    - Super-tiebreak display inconsistency -> centralize active-screen set score helper and use it in both card + modal.
+    - Navigation race on match end -> short-circuit modal auto-open whenever derived status is completed or finish navigation is in progress.

--- a/e2e/active-match.happy-path.spec.ts
+++ b/e2e/active-match.happy-path.spec.ts
@@ -6,10 +6,12 @@ test.describe('@happy-path @active-match Active match', () => {
   test('supports scoring flow, game completion, set updates, and side-switch prompts', async ({
     page
   }) => {
+    test.slow();
     await startMatch(page, {
       format: 'best-of-1',
       sideSwitchPrompts: true,
       servingIndicatorEnabled: true,
+      autoOpenSetsHistoryModal: false,
       team1Name: 'Lobos',
       team2Name: 'Rivals'
     });
@@ -26,7 +28,7 @@ test.describe('@happy-path @active-match Active match', () => {
     await expect(team1Panel).toContainText('40');
 
     await team1Panel.click();
-    await expect(page.getByTestId('set-row-0')).toContainText('1-0');
+    await expect(page.getByTestId('set-row-current')).toContainText('1-0');
     await expect(page.getByTestId('side-switch-prompt')).toBeVisible();
 
     await dismissSideSwitchPromptIfVisible(page);
@@ -37,7 +39,8 @@ test.describe('@happy-path @active-match Active match', () => {
     await startMatch(page, {
       format: 'best-of-1',
       sideSwitchPrompts: false,
-      servingIndicatorEnabled: false
+      servingIndicatorEnabled: false,
+      autoOpenSetsHistoryModal: false
     });
 
     await winQuickSet(page.getByTestId('team-panel-team-1'));

--- a/e2e/advantage-deuce.edge-case.spec.ts
+++ b/e2e/advantage-deuce.edge-case.spec.ts
@@ -4,11 +4,13 @@ import { clickNTimes, startMatch } from './helpers/match-flow';
 
 test.describe('@edge-case @active-match Advantage and deuce scoring', () => {
   test('requires a two-point advantage to close the game', async ({ page }) => {
+    test.slow();
     await startMatch(page, {
       format: 'best-of-1',
       gameMode: 'advantage',
       sideSwitchPrompts: false,
-      servingIndicatorEnabled: false
+      servingIndicatorEnabled: false,
+      autoOpenSetsHistoryModal: false
     });
 
     const team1Panel = page.getByTestId('team-panel-team-1');
@@ -23,7 +25,7 @@ test.describe('@edge-case @active-match Advantage and deuce scoring', () => {
     await team1Panel.click();
     await expect(team1Panel).toContainText('ad');
     await expect(team2Panel).toContainText('40');
-    await expect(page.getByTestId('set-row-0')).toContainText('0-0');
+    await expect(page.getByTestId('set-row-current')).toContainText('0-0');
 
     await team2Panel.click();
     await expect(team1Panel).toContainText('40');
@@ -32,10 +34,10 @@ test.describe('@edge-case @active-match Advantage and deuce scoring', () => {
     await team2Panel.click();
     await expect(team1Panel).toContainText('40');
     await expect(team2Panel).toContainText('ad');
-    await expect(page.getByTestId('set-row-0')).toContainText('0-0');
+    await expect(page.getByTestId('set-row-current')).toContainText('0-0');
 
     await team2Panel.click();
-    await expect(page.getByTestId('set-row-0')).toContainText('0-1');
+    await expect(page.getByTestId('set-row-current')).toContainText('0-1');
     await expect(team1Panel).toContainText('0');
     await expect(team2Panel).toContainText('0');
   });

--- a/e2e/golden-point.edge-case.spec.ts
+++ b/e2e/golden-point.edge-case.spec.ts
@@ -4,11 +4,13 @@ import { clickNTimes, startMatch } from './helpers/match-flow';
 
 test.describe('@edge-case @active-match Golden point scoring', () => {
   test('wins the game immediately on the point after deuce', async ({ page }) => {
+    test.slow();
     await startMatch(page, {
       format: 'best-of-1',
       gameMode: 'golden-point',
       sideSwitchPrompts: false,
-      servingIndicatorEnabled: false
+      servingIndicatorEnabled: false,
+      autoOpenSetsHistoryModal: false
     });
 
     const team1Panel = page.getByTestId('team-panel-team-1');
@@ -22,7 +24,7 @@ test.describe('@edge-case @active-match Golden point scoring', () => {
 
     await team1Panel.click();
 
-    await expect(page.getByTestId('set-row-0')).toContainText('1-0');
+    await expect(page.getByTestId('set-row-current')).toContainText('1-0');
     await expect(team1Panel).toContainText('0');
     await expect(team2Panel).toContainText('0');
     await expect(team1Panel).not.toContainText('ad');

--- a/e2e/helpers/match-flow.ts
+++ b/e2e/helpers/match-flow.ts
@@ -24,6 +24,7 @@ interface StartMatchOptions {
   servingIndicatorEnabled?: boolean;
   countdownTimerEnabled?: boolean;
   countdownTimerDuration?: CountdownTimerDuration;
+  resetPersistence?: boolean;
 }
 
 interface GotoSetupScreenOptions {
@@ -182,10 +183,11 @@ export async function startMatch(page: Page, options: StartMatchOptions = {}): P
     sideSwitchPrompts = false,
     servingIndicatorEnabled = false,
     countdownTimerEnabled = false,
-    countdownTimerDuration = 90
+    countdownTimerDuration = 90,
+    resetPersistence = true
   } = options;
 
-  await gotoSetupScreen(page, { resetPersistence: true });
+  await gotoSetupScreen(page, { resetPersistence });
 
   await page.getByRole('textbox', { name: /team 1/i }).fill(team1Name);
   await page.getByRole('textbox', { name: /team 2/i }).fill(team2Name);

--- a/e2e/helpers/match-flow.ts
+++ b/e2e/helpers/match-flow.ts
@@ -9,6 +9,7 @@ import type {
   MatchTeamId,
   SuperTiebreakTargetPoints
 } from '../../src/core/match/types';
+import { persistenceDatabaseName } from '../../src/lib/persistence/indexed-db';
 
 interface StartMatchOptions {
   team1Name?: string;
@@ -18,10 +19,15 @@ interface StartMatchOptions {
   initialServer?: MatchTeamId;
   decidingSetSuperTiebreak?: boolean;
   superTiebreakTargetPoints?: SuperTiebreakTargetPoints;
+  autoOpenSetsHistoryModal?: boolean;
   sideSwitchPrompts?: boolean;
   servingIndicatorEnabled?: boolean;
   countdownTimerEnabled?: boolean;
   countdownTimerDuration?: CountdownTimerDuration;
+}
+
+interface GotoSetupScreenOptions {
+  resetPersistence?: boolean;
 }
 
 const formatButtonLabels: Record<MatchFormat, RegExp> = {
@@ -36,7 +42,8 @@ const countdownDurationLabels: Record<CountdownTimerDuration, RegExp> = {
   120: /2:00 h/i
 };
 
-const setupReadyTimeoutMs = 15_000;
+const setupReadyAttemptTimeoutMs = 8_000;
+const setupReadyBudgetMs = 26_000;
 const maxSetupNavigationAttempts = 3;
 
 function isTransientNavigationError(error: unknown): boolean {
@@ -51,17 +58,54 @@ function isTransientNavigationError(error: unknown): boolean {
   );
 }
 
-async function waitForSetupScreenReady(page: Page): Promise<void> {
-  const startMatchButton = page.getByRole('button', { name: /start match/i });
+function isRetryableSetupReadinessError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
 
-  await expect(startMatchButton).toBeVisible({ timeout: setupReadyTimeoutMs });
-  await expect(startMatchButton).toBeEnabled();
-  await expect(page.getByRole('textbox', { name: /team 1/i })).toBeVisible({
-    timeout: setupReadyTimeoutMs
-  });
-  await expect(page.getByRole('textbox', { name: /team 2/i })).toBeVisible({
-    timeout: setupReadyTimeoutMs
-  });
+  return (
+    message.includes('expect(locator).toBeVisible() failed') ||
+    message.includes('expect(locator).toHaveCount() failed') ||
+    message.includes("getByTestId('rules-card')")
+  );
+}
+
+async function resetClientPersistenceForSetup(page: Page): Promise<void> {
+  await page.evaluate(
+    async ({ databaseName }) => {
+      localStorage.clear();
+      sessionStorage.clear();
+
+      if ('serviceWorker' in navigator) {
+        const registrations = await navigator.serviceWorker.getRegistrations();
+        await Promise.all(registrations.map((registration) => registration.unregister()));
+      }
+
+      if ('caches' in window) {
+        const cacheKeys = await caches.keys();
+        await Promise.all(cacheKeys.map((cacheKey) => caches.delete(cacheKey)));
+      }
+
+      await new Promise<void>((resolve) => {
+        const request = indexedDB.deleteDatabase(databaseName);
+
+        request.addEventListener('success', () => resolve());
+        request.addEventListener('error', () => resolve());
+        request.addEventListener('blocked', () => resolve());
+      });
+    },
+    { databaseName: persistenceDatabaseName }
+  );
+}
+
+async function waitForSetupScreenReady(page: Page, timeoutMs: number): Promise<void> {
+  // Keep setup readiness locale-agnostic: labels can change with i18n, but
+  // structure stays stable (rules card + two team inputs).
+  const rulesCard = page.getByTestId('rules-card');
+  const teamNameInputs = page.getByRole('textbox');
+
+  await expect(rulesCard).toBeVisible({ timeout: timeoutMs });
+  await expect(teamNameInputs).toHaveCount(2, { timeout: timeoutMs });
+  await expect(teamNameInputs.nth(0)).toBeVisible({ timeout: timeoutMs });
+  await expect(teamNameInputs.nth(1)).toBeVisible({ timeout: timeoutMs });
 }
 
 async function setToggle(page: Page, label: RegExp, checked: boolean): Promise<void> {
@@ -75,19 +119,49 @@ async function setToggle(page: Page, label: RegExp, checked: boolean): Promise<v
   await expect(toggle).toHaveAttribute('aria-checked', checked ? 'true' : 'false');
 }
 
-export async function gotoSetupScreen(page: Page): Promise<void> {
+export async function gotoSetupScreen(
+  page: Page,
+  options: GotoSetupScreenOptions = {}
+): Promise<void> {
+  const { resetPersistence = false } = options;
+  const startedAt = Date.now();
+  let didInitialOriginPersistenceReset = false;
+
   async function navigate(attempt: number): Promise<void> {
+    const elapsedMs = Date.now() - startedAt;
+    const remainingBudgetMs = setupReadyBudgetMs - elapsedMs;
+
+    if (remainingBudgetMs <= 0) {
+      throw new Error(
+        `Setup screen not ready within ${String(setupReadyBudgetMs)}ms total retry budget.`
+      );
+    }
+
+    const readinessTimeoutMs = Math.min(setupReadyAttemptTimeoutMs, remainingBudgetMs);
+
     try {
+      if (resetPersistence && !didInitialOriginPersistenceReset) {
+        await page.goto('/', { waitUntil: 'domcontentloaded' });
+        await resetClientPersistenceForSetup(page);
+        didInitialOriginPersistenceReset = true;
+      }
+
       await page.goto('/', { waitUntil: 'domcontentloaded' });
-      await waitForSetupScreenReady(page);
+      await waitForSetupScreenReady(page, readinessTimeoutMs);
     } catch (error) {
       const isLastAttempt = attempt === maxSetupNavigationAttempts;
+      const nextAttemptElapsedMs = Date.now() - startedAt;
+      const hasBudgetForRetry = nextAttemptElapsedMs < setupReadyBudgetMs;
 
-      if (isLastAttempt || !isTransientNavigationError(error)) {
+      if (
+        isLastAttempt ||
+        !hasBudgetForRetry ||
+        (!isTransientNavigationError(error) && !isRetryableSetupReadinessError(error))
+      ) {
         throw error;
       }
 
-      await page.waitForTimeout(400 * attempt);
+      await page.waitForTimeout(250 * attempt);
       await navigate(attempt + 1);
     }
   }
@@ -104,13 +178,14 @@ export async function startMatch(page: Page, options: StartMatchOptions = {}): P
     initialServer = 'team-1',
     decidingSetSuperTiebreak = false,
     superTiebreakTargetPoints = 11,
+    autoOpenSetsHistoryModal = true,
     sideSwitchPrompts = false,
     servingIndicatorEnabled = false,
     countdownTimerEnabled = false,
     countdownTimerDuration = 90
   } = options;
 
-  await gotoSetupScreen(page);
+  await gotoSetupScreen(page, { resetPersistence: true });
 
   await page.getByRole('textbox', { name: /team 1/i }).fill(team1Name);
   await page.getByRole('textbox', { name: /team 2/i }).fill(team2Name);
@@ -129,6 +204,7 @@ export async function startMatch(page: Page, options: StartMatchOptions = {}): P
     );
   }
 
+  await setToggle(page, /auto-open sets history/i, autoOpenSetsHistoryModal);
   await setToggle(page, /side-switch prompts/i, sideSwitchPrompts);
   await setToggle(page, /serving indicator/i, servingIndicatorEnabled);
   await setToggle(page, /countdown timer/i, countdownTimerEnabled);

--- a/e2e/match-end.happy-path.spec.ts
+++ b/e2e/match-end.happy-path.spec.ts
@@ -33,7 +33,11 @@ test.describe('@happy-path @match-end Match end', () => {
     await page.getByRole('button', { name: /continue/i }).click();
 
     await expect(page).toHaveURL(new RegExp(`/match/${record.matchId}$`));
-    await expect(page.getByTestId('set-row-0')).toContainText('6-0');
+    await expect(page.getByTestId('set-row-current')).toContainText('0-0');
+    await page.getByTestId('sets-card').click();
+    await expect(page.getByTestId('sets-history-modal-list')).toContainText(/6\s*-\s*0/);
+    await page.getByTestId('sets-history-modal-close').click();
+    await expect(page.getByTestId('sets-history-modal')).not.toBeAttached();
     await expect(page.getByTestId('team-panel-team-1')).toContainText('0');
 
     await page.getByTestId('team-panel-team-1').click();

--- a/e2e/persistence-recovery.edge-case.spec.ts
+++ b/e2e/persistence-recovery.edge-case.spec.ts
@@ -33,7 +33,7 @@ test.describe('@edge-case @setup @active-match @match-end Persistence recovery',
     await page.getByRole('button', { name: /resume match/i }).click();
 
     await expect(page).toHaveURL(new RegExp(`/match/${record.matchId}$`));
-    await expect(page.getByTestId('set-row-0')).toContainText('1-0');
+    await expect(page.getByTestId('set-row-current')).toContainText('1-0');
 
     await page.reload();
     await expect(page).toHaveURL(new RegExp(`/match/${record.matchId}$`));

--- a/e2e/responsive-layout.spec.ts
+++ b/e2e/responsive-layout.spec.ts
@@ -41,7 +41,8 @@ test.describe('@responsive Responsive layout', () => {
     await startMatch(page, {
       format: 'best-of-1',
       sideSwitchPrompts: false,
-      servingIndicatorEnabled: false
+      servingIndicatorEnabled: false,
+      autoOpenSetsHistoryModal: false
     });
 
     await expect(page.getByTestId('rotate-device-blocker')).toBeVisible();
@@ -56,7 +57,8 @@ test.describe('@responsive Responsive layout', () => {
       await startMatch(page, {
         format: 'best-of-1',
         sideSwitchPrompts: false,
-        servingIndicatorEnabled: false
+        servingIndicatorEnabled: false,
+        autoOpenSetsHistoryModal: false
       });
 
       await expect(page.getByTestId('rotate-device-blocker')).toHaveCount(0);
@@ -79,7 +81,8 @@ test.describe('@responsive Responsive layout', () => {
         team2Name: 'Team Beta',
         format: 'best-of-1',
         sideSwitchPrompts: false,
-        servingIndicatorEnabled: false
+        servingIndicatorEnabled: false,
+        autoOpenSetsHistoryModal: false
       });
 
       const isPortrait = isPortraitViewport(viewport);

--- a/e2e/tiebreaks.edge-case.spec.ts
+++ b/e2e/tiebreaks.edge-case.spec.ts
@@ -13,7 +13,8 @@ test.describe('@edge-case @active-match @match-end Tiebreak flows', () => {
     await startMatch(page, {
       format: 'best-of-1',
       sideSwitchPrompts: false,
-      servingIndicatorEnabled: false
+      servingIndicatorEnabled: false,
+      autoOpenSetsHistoryModal: false
     });
 
     const team1Panel = page.getByTestId('team-panel-team-1');
@@ -25,7 +26,7 @@ test.describe('@edge-case @active-match @match-end Tiebreak flows', () => {
       await winQuickGame(team2Panel);
     }, Promise.resolve());
 
-    await expect(page.getByTestId('set-row-0')).toContainText('6-6');
+    await expect(page.getByTestId('set-row-current')).toContainText('6-6');
 
     await clickNTimes(team1Panel, 2);
     await team2Panel.click();
@@ -48,7 +49,8 @@ test.describe('@edge-case @active-match @match-end Tiebreak flows', () => {
       format: 'best-of-3',
       decidingSetSuperTiebreak: true,
       sideSwitchPrompts: false,
-      servingIndicatorEnabled: false
+      servingIndicatorEnabled: false,
+      autoOpenSetsHistoryModal: false
     });
 
     const team1Panel = page.getByTestId('team-panel-team-1');
@@ -79,7 +81,8 @@ test.describe('@edge-case @active-match @match-end Tiebreak flows', () => {
       decidingSetSuperTiebreak: true,
       superTiebreakTargetPoints: 9,
       sideSwitchPrompts: false,
-      servingIndicatorEnabled: false
+      servingIndicatorEnabled: false,
+      autoOpenSetsHistoryModal: false
     });
 
     const team1Panel = page.getByTestId('team-panel-team-1');
@@ -114,6 +117,7 @@ test.describe('@edge-case @active-match @match-end Tiebreak flows', () => {
       format: 'best-of-1',
       sideSwitchPrompts: false,
       servingIndicatorEnabled: false,
+      autoOpenSetsHistoryModal: false,
       countdownTimerEnabled: false
     });
 

--- a/e2e/undo.edge-case.spec.ts
+++ b/e2e/undo.edge-case.spec.ts
@@ -7,7 +7,8 @@ test.describe('@edge-case @active-match Undo scoring', () => {
     await startMatch(page, {
       format: 'best-of-1',
       sideSwitchPrompts: false,
-      servingIndicatorEnabled: false
+      servingIndicatorEnabled: false,
+      autoOpenSetsHistoryModal: false
     });
 
     const team1Panel = page.getByTestId('team-panel-team-1');
@@ -27,10 +28,10 @@ test.describe('@edge-case @active-match Undo scoring', () => {
     await expect(team1Panel).toContainText('0');
 
     await winQuickGame(team1Panel);
-    await expect(page.getByTestId('set-row-0')).toContainText('1-0');
+    await expect(page.getByTestId('set-row-current')).toContainText('1-0');
 
     await team1UndoButton.click();
-    await expect(page.getByTestId('set-row-0')).toContainText('0-0');
+    await expect(page.getByTestId('set-row-current')).toContainText('0-0');
     await expect(team1Panel).toContainText('40');
   });
 });

--- a/src/components/ActiveMatchScreen/ActiveMatchScreen.module.css
+++ b/src/components/ActiveMatchScreen/ActiveMatchScreen.module.css
@@ -20,7 +20,7 @@
 
 .setsOverlay {
   position: absolute;
-  bottom: 5%;
+  bottom: 2%;
   left: 50%;
   z-index: var(--base-priority-s);
   transform: translate(-50%, 0%);

--- a/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
+++ b/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useRouter } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 
@@ -28,8 +28,10 @@ import { getMatchTeamName } from '@/core/match/team-name';
 import type { MatchAction, MatchSetup, MatchTeamId } from '@/core/match/types';
 
 import { SetsCard } from './SetsCard/SetsCard';
+import { SetsHistoryModal } from './SetsHistoryModal/SetsHistoryModal';
 import { SideSwitchPrompt } from './SideSwitchPrompt/SideSwitchPrompt';
 import { TeamPanel } from './TeamPanel/TeamPanel';
+import { getSetsHistoryAutoOpenSignature } from './sets-history';
 import { useMatchAnnouncements } from './useMatchAnnouncements';
 import { useMatchSession } from './useMatchSession';
 import { useMatchTimer } from './useMatchTimer';
@@ -63,6 +65,10 @@ export function ActiveMatchScreen({
   const [isNavigatingToFinish, setIsNavigatingToFinish] = useState(false);
   const [remoteConfig, setRemoteConfig] = useState<RemoteControllerConfig | null>(null);
   const [isCompactHeight, setIsCompactHeight] = useState(false);
+  const [isSetsHistoryOpen, setIsSetsHistoryOpen] = useState(false);
+  const [setsHistoryOpenToken, setSetsHistoryOpenToken] = useState(0);
+  const previousSetsHistorySignatureRef = useRef<string | null>(null);
+  const previousActionCountRef = useRef(initialActions.length);
 
   const retryHistorySave = useCallback(async () => {
     const currentMatch = await loadCurrentMatch();
@@ -371,6 +377,48 @@ export function ActiveMatchScreen({
     setSideSwitchDismissed(true);
   }, []);
 
+  const handleOpenSetsHistory = useCallback(() => {
+    setIsSetsHistoryOpen(true);
+    setSetsHistoryOpenToken((currentToken) => currentToken + 1);
+  }, []);
+
+  const handleCloseSetsHistory = useCallback(() => {
+    setIsSetsHistoryOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (isMatchCompleted) {
+      setIsSetsHistoryOpen(false);
+    }
+  }, [isMatchCompleted]);
+
+  useEffect(() => {
+    const nextSignature = getSetsHistoryAutoOpenSignature(state.sets);
+    const previousSignature = previousSetsHistorySignatureRef.current;
+    const hasNewScoringAction = snapshot.actions.length > previousActionCountRef.current;
+
+    if (
+      previousSignature !== null &&
+      hasNewScoringAction &&
+      previousSignature !== nextSignature &&
+      setup.autoOpenSetsHistoryModal &&
+      !isMatchCompleted &&
+      !isNavigatingToFinish
+    ) {
+      setIsSetsHistoryOpen(true);
+      setSetsHistoryOpenToken((currentToken) => currentToken + 1);
+    }
+
+    previousSetsHistorySignatureRef.current = nextSignature;
+    previousActionCountRef.current = snapshot.actions.length;
+  }, [
+    isMatchCompleted,
+    isNavigatingToFinish,
+    setup.autoOpenSetsHistoryModal,
+    snapshot.actions.length,
+    state.sets
+  ]);
+
   const shouldShowSideSwitch =
     sideSwitch.shouldPrompt && setup.sideSwitchPrompts && !sideSwitchDismissed;
   const timerLabelKey = countdownEnabled ? 'match.timer.countdownLabel' : 'match.timer.label';
@@ -492,9 +540,20 @@ export function ActiveMatchScreen({
           </div>
 
           <div className={styles.setsOverlay}>
-            <SetsCard sets={state.sets} currentSetIndex={activeSetIndex} />
+            <SetsCard
+              sets={state.sets}
+              currentSetIndex={activeSetIndex}
+              onOpenHistory={handleOpenSetsHistory}
+            />
           </div>
         </div>
+
+        <SetsHistoryModal
+          isOpen={isSetsHistoryOpen}
+          openToken={setsHistoryOpenToken}
+          sets={state.sets}
+          onClose={handleCloseSetsHistory}
+        />
 
         <SideSwitchPrompt
           isOpen={shouldShowSideSwitch}

--- a/src/components/ActiveMatchScreen/SetsCard/SetsCard.module.css
+++ b/src/components/ActiveMatchScreen/SetsCard/SetsCard.module.css
@@ -1,11 +1,27 @@
+.trigger {
+  width: fit-content;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: inherit;
+  cursor: pointer;
+}
+
+.trigger:focus-visible {
+  outline: var(--base-space-2) solid var(--semantic-color-border-accent-primary);
+  outline-offset: var(--base-space-2);
+  border-radius: var(--component-card-overlay-radius);
+}
+
 /* SetsCard.module.css - Following Pencil design node ID: pGBiU */
 
 .container {
   display: flex;
   flex-direction: column;
-  gap: var(--base-space-8);
-  width: var(--app-scoreboard-sets-overlay-width);
-  max-height: calc(var(--base-space-8) * 25);
+  gap: var(--base-space-10);
   padding: var(--component-card-overlay-padding-y) var(--component-card-overlay-padding-x);
   border: 1px solid var(--component-card-overlay-border);
   border-radius: var(--component-card-overlay-radius);
@@ -21,27 +37,11 @@
   text-transform: uppercase;
 }
 
-.setsGrid {
-  display: flex;
-  flex-direction: column-reverse;
-  gap: var(--base-space-6);
-  max-height: calc(var(--base-space-8) * 24);
-  overflow-y: auto;
-}
-
 .setRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--base-space-12);
-}
-
-.setNumber {
-  font-family: var(--semantic-typography-family-body);
-  font-size: var(--semantic-typography-size-label-md);
-  font-weight: var(--base-font-weight-semibold);
-  color: var(--semantic-color-content-secondary);
-  line-height: var(--semantic-typography-line-height-body);
 }
 
 .setScore {
@@ -55,8 +55,9 @@
 .team2Games,
 .divider {
   font-family: var(--semantic-typography-family-display);
-  font-size: var(--semantic-typography-size-set-score);
+  font-size: calc(var(--semantic-typography-size-display-md) * 2.5);
   font-weight: var(--semantic-typography-weight-heading);
+  line-height: var(--semantic-typography-line-height-display);
 }
 
 .team1Games,
@@ -77,16 +78,11 @@
   .setRow {
     gap: var(--base-space-8);
   }
-
-  .setNumber {
-    font-size: var(--base-font-size-14);
-  }
 }
 
 @media (height <= 480px) {
   .container {
     width: calc(var(--base-space-8) * 15);
-    max-height: calc(var(--base-space-8) * 18);
     gap: var(--base-space-6);
     padding: var(--base-space-10) var(--base-space-12);
   }
@@ -95,17 +91,8 @@
     font-size: var(--base-font-size-11);
   }
 
-  .setsGrid {
-    gap: var(--base-space-4);
-    max-height: calc(var(--base-space-8) * 15);
-  }
-
   .setRow {
     gap: var(--base-space-8);
-  }
-
-  .setNumber {
-    font-size: var(--base-font-size-12);
   }
 
   .team1Games,

--- a/src/components/ActiveMatchScreen/SetsCard/SetsCard.tsx
+++ b/src/components/ActiveMatchScreen/SetsCard/SetsCard.tsx
@@ -1,62 +1,61 @@
 import { useTranslation } from 'react-i18next';
 
 import type { MatchSetState } from '@/core/match/types';
-import { Card } from '@/components/ui/Card/Card';
+
+import { getCurrentSet, getSetDisplayScore } from '../sets-history';
 
 import styles from './SetsCard.module.css';
-import { useEffect, useRef } from 'react';
 
 interface SetsCardProps {
   sets: MatchSetState[];
   currentSetIndex: number | null;
+  onOpenHistory?: () => void;
 }
 
 /**
- * SetsCard component - Displays completed and in-progress set scores.
- * Follows Pencil design node ID: pGBiU
- * Container: 180px width, corner radius 20px
+ * SetsCard component - compact trigger showing current set score only.
  */
-export function SetsCard({ sets, currentSetIndex }: SetsCardProps) {
+export function SetsCard({ sets, currentSetIndex, onOpenHistory }: SetsCardProps) {
   const { t } = useTranslation();
 
-  const setsGridRef = useRef<HTMLDivElement>(null);
+  const currentSet = getCurrentSet(sets, currentSetIndex);
+  const currentScore = getSetDisplayScore(currentSet);
 
-  useEffect(() => {
-    const setsGrid = setsGridRef.current;
-    if (setsGrid) {
-      setsGrid.scroll({ top: -setsGrid.scrollHeight, behavior: 'smooth' });
-    }
-  }, [currentSetIndex, sets.length]);
+  const cardContent = (
+    <>
+      <span className={styles.label}>{t('match.sets.label')}</span>
+      <span className={styles.setRow} data-testid="set-row-current">
+        <span className={styles.setScore} data-testid="set-score-current">
+          <span className={styles.team1Games}>{currentScore['team-1']}</span>
+          <span className={styles.divider}>-</span>
+          <span className={styles.team2Games}>{currentScore['team-2']}</span>
+        </span>
+      </span>
+    </>
+  );
+
+  const historyTriggerLabel = t('match.sets.openHistoryLabel', {
+    team1: currentScore['team-1'],
+    team2: currentScore['team-2']
+  });
+
+  if (typeof onOpenHistory !== 'function') {
+    return (
+      <div className={styles.container} data-testid="sets-card">
+        {cardContent}
+      </div>
+    );
+  }
 
   return (
-    <Card className={styles.container} data-testid="sets-card">
-      <span className={styles.label}>{t('match.sets.label')}</span>
-      <div className={styles.setsGrid} ref={setsGridRef}>
-        {sets.map((set, index) => {
-          const isCurrent = index === currentSetIndex;
-          const setLabel = isCurrent
-            ? t('match.sets.currentShort')
-            : t('match.sets.setLabel', { number: index + 1 });
-
-          return (
-            <div
-              key={set.index}
-              className={styles.setRow}
-              aria-current={isCurrent ? 'true' : undefined}
-              data-testid={`set-row-${index}`}
-            >
-              <span className={styles.setNumber} data-testid={`set-number-${index}`}>
-                {setLabel}
-              </span>
-              <span className={styles.setScore}>
-                <span className={styles.team1Games}>{set.games['team-1']}</span>
-                <span className={styles.divider}>-</span>
-                <span className={styles.team2Games}>{set.games['team-2']}</span>
-              </span>
-            </div>
-          );
-        })}
-      </div>
-    </Card>
+    <button
+      type="button"
+      className={styles.trigger}
+      data-testid="sets-card"
+      aria-label={historyTriggerLabel}
+      onClick={onOpenHistory}
+    >
+      <span className={styles.container}>{cardContent}</span>
+    </button>
   );
 }

--- a/src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.module.css
+++ b/src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.module.css
@@ -1,0 +1,116 @@
+.overlay {
+  composes: sharedoverlay from '../../../styles/shared-overlays.module.css';
+}
+
+.container {
+  pointer-events: auto;
+  composes: modalcontainer from '../../../styles/shared-setup-modal.module.css';
+  width: min(calc(100vw - (var(--base-space-16) * 2)), calc(var(--base-space-40) * 13));
+  max-height: calc(100dvh - (var(--base-space-16) * 2));
+  gap: var(--base-space-16);
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--base-space-12);
+}
+
+.title {
+  margin: 0;
+  font-family: var(--semantic-typography-family-display);
+  font-size: calc(var(--semantic-typography-size-display-md) * 2);
+  font-weight: var(--semantic-typography-weight-display);
+  line-height: var(--semantic-typography-line-height-heading);
+  color: var(--semantic-color-content-primary);
+  text-align: center;
+  flex: 1;
+}
+
+.closeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--base-space-32);
+  min-height: var(--base-space-32);
+  border: 1px solid var(--semantic-color-border-subtle);
+  border-radius: var(--base-radius-16);
+  background-color: transparent;
+  color: var(--semantic-color-content-secondary);
+  font-family: var(--semantic-typography-family-display);
+  font-size: var(--base-font-size-18);
+  font-weight: var(--semantic-typography-weight-heading);
+  line-height: 1;
+  cursor: pointer;
+}
+
+.closeButton:focus-visible {
+  outline: var(--base-space-2) solid var(--semantic-color-border-accent-primary);
+  outline-offset: var(--base-space-2);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--base-space-10);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--base-space-12);
+  padding: var(--base-space-10) var(--base-space-12);
+  border: 1px solid var(--semantic-color-border-subtle);
+  border-radius: var(--base-radius-16);
+  background-color: var(--semantic-color-background-canvas);
+}
+
+.setLabel {
+  font-family: var(--semantic-typography-family-body);
+  font-size: var(--semantic-typography-size-title-xl);
+  font-weight: var(--semantic-typography-weight-strong);
+  color: var(--semantic-color-content-secondary);
+}
+
+.score {
+  font-family: var(--semantic-typography-family-display);
+  font-size: var(--semantic-typography-size-display-md);
+  font-weight: var(--semantic-typography-weight-display);
+  color: var(--semantic-color-content-primary);
+}
+
+.emptyState {
+  margin: 0;
+  padding: var(--base-space-10) var(--base-space-12);
+  border: 1px solid var(--semantic-color-border-subtle);
+  border-radius: var(--base-radius-16);
+  background-color: var(--semantic-color-background-canvas);
+  font-family: var(--semantic-typography-family-body);
+  font-size: var(--semantic-typography-size-title-sm);
+  font-weight: var(--semantic-typography-weight-regular);
+  color: var(--semantic-color-content-secondary);
+  text-align: center;
+}
+
+@media (width < 768px) {
+  .container {
+    width: min(
+      calc(100vw - (var(--base-space-12) * 2)),
+      calc((var(--base-space-40) * 10) + var(--base-space-20))
+    );
+    padding: var(--base-space-16);
+  }
+
+  .title {
+    font-size: var(--semantic-typography-size-title-sm);
+  }
+
+  .score {
+    font-size: var(--semantic-typography-size-title-sm);
+  }
+}

--- a/src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx
+++ b/src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx
@@ -1,0 +1,149 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type ComponentProps,
+  type HTMLAttributes
+} from 'react';
+import { Dialog } from '@base-ui/react/dialog';
+import { useTranslation } from 'react-i18next';
+
+import type { MatchSetState } from '@/core/match/types';
+
+import { getSetDisplayScore, getSetsWonScore } from '../sets-history';
+
+import styles from './SetsHistoryModal.module.css';
+
+interface SetsHistoryModalProps {
+  isOpen: boolean;
+  openToken: number;
+  sets: MatchSetState[];
+  onClose: () => void;
+  autoCloseDelay?: number;
+}
+
+type DialogBackdropRenderProps = Parameters<
+  Extract<ComponentProps<typeof Dialog.Backdrop>['render'], (...args: never[]) => unknown>
+>[0];
+type DialogPopupRenderProps = Parameters<
+  Extract<ComponentProps<typeof Dialog.Popup>['render'], (...args: never[]) => unknown>
+>[0];
+
+export function SetsHistoryModal({
+  isOpen,
+  openToken,
+  sets,
+  onClose,
+  autoCloseDelay = 30000
+}: SetsHistoryModalProps) {
+  const { t } = useTranslation();
+  const portalContainerRef = useRef<HTMLDivElement | null>(null);
+  const setsWonScore = getSetsWonScore(sets);
+  const title = t('match.sets.currentSetScoreHeadline', {
+    team1: setsWonScore['team-1'],
+    team2: setsWonScore['team-2']
+  });
+
+  const handleTitleRender = useCallback(
+    (props: HTMLAttributes<HTMLHeadingElement>) => (
+      <h2 {...props} className={styles.title}>
+        {title}
+      </h2>
+    ),
+    [title]
+  );
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  const setRows = useMemo(
+    () =>
+      sets
+        .filter((set) => set.completed)
+        .map((set) => {
+          const setScore = getSetDisplayScore(set);
+
+          return {
+            setNumber: set.index,
+            team1: setScore['team-1'],
+            team2: setScore['team-2']
+          };
+        }),
+    [sets]
+  );
+
+  const handleBackdropRender = useCallback(
+    (props: DialogBackdropRenderProps) => (
+      <div {...props} className={styles.overlay} data-testid="sets-history-modal-backdrop" />
+    ),
+    []
+  );
+
+  const handlePopupRender = useCallback(
+    (props: DialogPopupRenderProps) => (
+      <div {...props} className={styles.container} data-testid="sets-history-modal">
+        <header className={styles.header}>
+          <Dialog.Title render={handleTitleRender} />
+          <Dialog.Close
+            className={styles.closeButton}
+            aria-label={t('common.close')}
+            data-testid="sets-history-modal-close"
+          >
+            <span aria-hidden="true">×</span>
+          </Dialog.Close>
+        </header>
+
+        {setRows.length > 0 ? (
+          <ul className={styles.list} data-testid="sets-history-modal-list">
+            {setRows.map((row) => (
+              <li key={row.setNumber} className={styles.row}>
+                <span className={styles.setLabel}>
+                  {t('match.sets.setLabel', { number: row.setNumber })}
+                </span>
+                <span className={styles.score}>{`${row.team1} - ${row.team2}`}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className={styles.emptyState} data-testid="sets-history-modal-empty-state">
+            {t('match.sets.emptyHistory')}
+          </p>
+        )}
+      </div>
+    ),
+    [handleTitleRender, setRows, t]
+  );
+
+  useEffect(() => {
+    if (!isOpen || autoCloseDelay <= 0) {
+      return undefined;
+    }
+
+    const timeoutId = setTimeout(() => {
+      onClose();
+    }, autoCloseDelay);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [autoCloseDelay, isOpen, onClose, openToken]);
+
+  return (
+    <>
+      <div ref={portalContainerRef} />
+      <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
+        <Dialog.Portal container={portalContainerRef}>
+          <Dialog.Backdrop render={handleBackdropRender} />
+          <Dialog.Popup render={handlePopupRender} />
+        </Dialog.Portal>
+      </Dialog.Root>
+    </>
+  );
+}

--- a/src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx
+++ b/src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx
@@ -40,7 +40,7 @@ export function SetsHistoryModal({
   const { t } = useTranslation();
   const portalContainerRef = useRef<HTMLDivElement | null>(null);
   const setsWonScore = getSetsWonScore(sets);
-  const title = t('match.sets.currentSetScoreHeadline', {
+  const title = t('match.sets.overallSetsScoreHeadline', {
     team1: setsWonScore['team-1'],
     team2: setsWonScore['team-2']
   });

--- a/src/components/ActiveMatchScreen/sets-history.ts
+++ b/src/components/ActiveMatchScreen/sets-history.ts
@@ -1,0 +1,76 @@
+import type { CompletedMatchSet, MatchSetState, TeamScore } from '@/core/match/types';
+
+type LegacyCompletedSuperTiebreakSetShape = {
+  game?: {
+    kind?: unknown;
+    points?: TeamScore<number>;
+  };
+};
+
+function getCompletedSuperTiebreakScore(set: CompletedMatchSet): TeamScore<number> {
+  if (set.tiebreakPoints !== null) {
+    return set.tiebreakPoints;
+  }
+
+  const legacyShape = set as MatchSetState & LegacyCompletedSuperTiebreakSetShape;
+  if (legacyShape.game?.kind === 'tiebreak' && legacyShape.game.points !== undefined) {
+    return legacyShape.game.points;
+  }
+
+  return set.games;
+}
+
+export function getCurrentSet(
+  sets: MatchSetState[],
+  currentSetIndex: number | null
+): MatchSetState | null {
+  if (currentSetIndex !== null && currentSetIndex >= 0 && currentSetIndex < sets.length) {
+    return sets[currentSetIndex] ?? null;
+  }
+
+  return sets[sets.length - 1] ?? null;
+}
+
+export function getSetDisplayScore(set: MatchSetState | null): TeamScore<number> {
+  if (set === null) {
+    return { 'team-1': 0, 'team-2': 0 };
+  }
+
+  if (set.completed) {
+    if (set.mode === 'super-tiebreak') {
+      return getCompletedSuperTiebreakScore(set);
+    }
+
+    return set.games;
+  }
+
+  if (set.mode === 'super-tiebreak' && set.game.kind === 'tiebreak') {
+    return set.game.points;
+  }
+
+  return set.games;
+}
+
+export function getSetsWonScore(sets: MatchSetState[]): TeamScore<number> {
+  return sets.reduce<TeamScore<number>>(
+    (score, set) => {
+      if (!set.completed || typeof set.winner !== 'string') {
+        return score;
+      }
+
+      score[set.winner] += 1;
+      return score;
+    },
+    { 'team-1': 0, 'team-2': 0 }
+  );
+}
+
+export function getSetsHistoryAutoOpenSignature(sets: MatchSetState[]): string {
+  return sets
+    .filter((set) => set.completed)
+    .map((set) => {
+      const score = getSetDisplayScore(set);
+      return `${set.index}:${score['team-1']}-${score['team-2']}`;
+    })
+    .join('|');
+}

--- a/src/components/SetupScreen/SetupScreen.tsx
+++ b/src/components/SetupScreen/SetupScreen.tsx
@@ -105,6 +105,7 @@ export function SetupScreen() {
     updateDecidingSetSuperTiebreak,
     updateAudioAnnouncementsEnabled,
     updateVoiceName,
+    updateAutoOpenSetsHistoryModal,
     updateSideSwitchPrompts,
     updateServingIndicatorEnabled,
     updateCountdownTimerEnabled,
@@ -176,6 +177,7 @@ export function SetupScreen() {
         servingIndicatorEnabled: formData.servingIndicatorEnabled,
         countdownTimerEnabled: formData.countdownTimerEnabled,
         countdownTimerDuration: formData.countdownTimerDuration,
+        autoOpenSetsHistoryModal: formData.autoOpenSetsHistoryModal,
         sideSwitchPrompts: formData.sideSwitchPrompts,
         sides: [
           { id: 'team-1' as const, playerNames: [formData.team1Name] },
@@ -617,6 +619,15 @@ export function SetupScreen() {
               onChange={updateServingIndicatorEnabled}
               label={t('setup.rules.servingIndicator')}
               hint={t('setup.rules.servingIndicatorHint')}
+            />
+
+            <Divider />
+
+            <Toggle
+              checked={formData.autoOpenSetsHistoryModal}
+              onChange={updateAutoOpenSetsHistoryModal}
+              label={t('setup.rules.autoOpenSetsHistoryModal')}
+              hint={t('setup.rules.autoOpenSetsHistoryModalHint')}
             />
 
             <Divider />

--- a/src/components/SetupScreen/types.ts
+++ b/src/components/SetupScreen/types.ts
@@ -19,6 +19,7 @@ export interface SetupFormData {
   servingIndicatorEnabled: boolean;
   countdownTimerEnabled: boolean;
   countdownTimerDuration: CountdownTimerDuration;
+  autoOpenSetsHistoryModal: boolean;
   sideSwitchPrompts: boolean;
 }
 

--- a/src/components/SetupScreen/useSetupForm.ts
+++ b/src/components/SetupScreen/useSetupForm.ts
@@ -53,7 +53,8 @@ export function useSetupForm() {
     servingIndicatorEnabled: defaultServingIndicatorEnabled,
     countdownTimerEnabled: defaultCountdownTimerEnabled,
     countdownTimerDuration: defaultCountdownTimerDuration,
-    sideSwitchPrompts: true
+    autoOpenSetsHistoryModal: true,
+    sideSwitchPrompts: false
   });
 
   const [errors, setErrors] = useState<FieldErrors>({});
@@ -100,6 +101,10 @@ export function useSetupForm() {
             servingIndicatorEnabled: setupPreferences.servingIndicatorEnabled,
             countdownTimerEnabled: setupPreferences.countdownTimerEnabled,
             countdownTimerDuration: setupPreferences.countdownTimerDuration,
+            autoOpenSetsHistoryModal:
+              typeof setupPreferences.autoOpenSetsHistoryModal === 'boolean'
+                ? setupPreferences.autoOpenSetsHistoryModal
+                : true,
             sideSwitchPrompts: setupPreferences.sideSwitchPrompts,
             format: setupPreferences.format,
             gameMode: setupPreferences.gameMode,
@@ -132,6 +137,7 @@ export function useSetupForm() {
       servingIndicatorEnabled: formData.servingIndicatorEnabled,
       countdownTimerEnabled: formData.countdownTimerEnabled,
       countdownTimerDuration: formData.countdownTimerDuration,
+      autoOpenSetsHistoryModal: formData.autoOpenSetsHistoryModal,
       sideSwitchPrompts: formData.sideSwitchPrompts,
       format: formData.format,
       gameMode: formData.gameMode,
@@ -166,6 +172,7 @@ export function useSetupForm() {
     formData.audioAnnouncementsEnabled,
     formData.countdownTimerDuration,
     formData.countdownTimerEnabled,
+    formData.autoOpenSetsHistoryModal,
     formData.decidingSetSuperTiebreak,
     formData.format,
     formData.gameMode,
@@ -254,6 +261,13 @@ export function useSetupForm() {
     [updateField]
   );
 
+  const updateAutoOpenSetsHistoryModal = useCallback(
+    (enabled: boolean) => {
+      updateField('autoOpenSetsHistoryModal', enabled);
+    },
+    [updateField]
+  );
+
   const updateAudioAnnouncementsEnabled = useCallback(
     (enabled: boolean) => {
       updateField('audioAnnouncementsEnabled', enabled);
@@ -314,6 +328,7 @@ export function useSetupForm() {
     updateAudioAnnouncementsEnabled,
     updateVoiceName,
     updateSideSwitchPrompts,
+    updateAutoOpenSetsHistoryModal,
     updateServingIndicatorEnabled,
     updateCountdownTimerEnabled,
     updateCountdownTimerDuration,
@@ -330,6 +345,7 @@ function toPersistedSetupPreferenceSlice(
         | 'servingIndicatorEnabled'
         | 'countdownTimerEnabled'
         | 'countdownTimerDuration'
+        | 'autoOpenSetsHistoryModal'
         | 'sideSwitchPrompts'
         | 'format'
         | 'gameMode'
@@ -342,6 +358,7 @@ function toPersistedSetupPreferenceSlice(
         | 'servingIndicatorEnabled'
         | 'countdownTimerEnabled'
         | 'countdownTimerDuration'
+        | 'autoOpenSetsHistoryModal'
         | 'sideSwitchPrompts'
         | 'format'
         | 'gameMode'
@@ -354,6 +371,8 @@ function toPersistedSetupPreferenceSlice(
     servingIndicatorEnabled: data.servingIndicatorEnabled,
     countdownTimerEnabled: data.countdownTimerEnabled,
     countdownTimerDuration: data.countdownTimerDuration,
+    autoOpenSetsHistoryModal:
+      typeof data.autoOpenSetsHistoryModal === 'boolean' ? data.autoOpenSetsHistoryModal : true,
     sideSwitchPrompts: data.sideSwitchPrompts,
     format: data.format,
     gameMode: data.gameMode,
@@ -371,6 +390,7 @@ function areSetupPreferenceSlicesEqual(
     left.servingIndicatorEnabled === right.servingIndicatorEnabled &&
     left.countdownTimerEnabled === right.countdownTimerEnabled &&
     left.countdownTimerDuration === right.countdownTimerDuration &&
+    left.autoOpenSetsHistoryModal === right.autoOpenSetsHistoryModal &&
     left.sideSwitchPrompts === right.sideSwitchPrompts &&
     left.format === right.format &&
     left.gameMode === right.gameMode &&

--- a/src/core/match/types.ts
+++ b/src/core/match/types.ts
@@ -36,6 +36,7 @@ export interface MatchSetupInput {
   servingIndicatorEnabled: boolean;
   countdownTimerEnabled: boolean;
   countdownTimerDuration: CountdownTimerDuration;
+  autoOpenSetsHistoryModal?: boolean;
   superTiebreakTargetPoints?: SuperTiebreakTargetPoints;
   bestOfOneDecidingBehavior?: BestOfOneDecidingBehavior;
   sideSwitchPrompts: boolean;
@@ -51,6 +52,7 @@ export interface MatchSetup {
   servingIndicatorEnabled: boolean;
   countdownTimerEnabled: boolean;
   countdownTimerDuration: CountdownTimerDuration;
+  autoOpenSetsHistoryModal: boolean;
   superTiebreakTargetPoints: PersistedSuperTiebreakTargetPoints;
   bestOfOneDecidingBehavior: BestOfOneDecidingBehavior;
   sideSwitchPrompts: boolean;

--- a/src/core/match/validation.ts
+++ b/src/core/match/validation.ts
@@ -212,6 +212,7 @@ export function validateMatchSetup(input: unknown): MatchSetupValidationResult {
   const servingIndicatorEnabledValue = input.servingIndicatorEnabled;
   const countdownTimerEnabledValue = input.countdownTimerEnabled;
   const countdownTimerDurationValue = input.countdownTimerDuration;
+  const autoOpenSetsHistoryModalValue = input.autoOpenSetsHistoryModal;
   const superTiebreakTargetPointsValue = input.superTiebreakTargetPoints;
   const bestOfOneDecidingBehaviorValue = input.bestOfOneDecidingBehavior;
   const sideSwitchPromptsValue = input.sideSwitchPrompts;
@@ -225,6 +226,7 @@ export function validateMatchSetup(input: unknown): MatchSetupValidationResult {
   let servingIndicatorEnabled: boolean | null = null;
   let countdownTimerEnabled: boolean | null = null;
   let countdownTimerDuration: CountdownTimerDuration | null = null;
+  let autoOpenSetsHistoryModal = true;
   let superTiebreakTargetPoints: SuperTiebreakTargetPoints = defaultSuperTiebreakTargetPoints;
   let sideSwitchPrompts: boolean | null = null;
   let bestOfOneDecidingBehavior: BestOfOneDecidingBehavior | undefined;
@@ -292,6 +294,17 @@ export function validateMatchSetup(input: unknown): MatchSetupValidationResult {
       createIssue(
         'countdownTimerDuration',
         `Unsupported countdown timer duration: ${describeValue(countdownTimerDurationValue)}`
+      )
+    );
+  }
+
+  if (typeof autoOpenSetsHistoryModalValue === 'boolean') {
+    autoOpenSetsHistoryModal = autoOpenSetsHistoryModalValue;
+  } else if (typeof autoOpenSetsHistoryModalValue !== 'undefined') {
+    issues.push(
+      createIssue(
+        'autoOpenSetsHistoryModal',
+        'Auto-open sets history modal must be a boolean value.'
       )
     );
   }
@@ -407,6 +420,7 @@ export function validateMatchSetup(input: unknown): MatchSetupValidationResult {
       servingIndicatorEnabled,
       countdownTimerEnabled,
       countdownTimerDuration,
+      autoOpenSetsHistoryModal,
       superTiebreakTargetPoints,
       bestOfOneDecidingBehavior: normalizedBestOfOneDecidingBehavior,
       sideSwitchPrompts,

--- a/src/lib/current-match/persistence.ts
+++ b/src/lib/current-match/persistence.ts
@@ -223,9 +223,12 @@ function parseMatchSetup(
   }
 ): MatchSetup {
   const setup = parseRecord(input);
+  const isInProgress = typeof options?.finishedAt === 'undefined';
   const shouldUseLegacySuperTiebreakTarget =
-    typeof options?.finishedAt === 'undefined' &&
+    isInProgress &&
     options?.legacyInProgressSuperTiebreakTargetPoints === legacySuperTiebreakTargetPoints;
+  const shouldUseLegacyInProgressSideSwitchPrompts =
+    isInProgress && typeof setup.sideSwitchPrompts === 'undefined';
 
   const setupInput = {
     format: setup.format,
@@ -247,10 +250,12 @@ function parseMatchSetup(
     countdownTimerDuration: isCountdownTimerDuration(setup.countdownTimerDuration)
       ? setup.countdownTimerDuration
       : defaultCountdownTimerDuration,
+    autoOpenSetsHistoryModal:
+      typeof setup.autoOpenSetsHistoryModal === 'boolean' ? setup.autoOpenSetsHistoryModal : true,
     superTiebreakTargetPoints: isSuperTiebreakTargetPoints(setup.superTiebreakTargetPoints)
       ? setup.superTiebreakTargetPoints
       : undefined,
-    sideSwitchPrompts: setup.sideSwitchPrompts,
+    sideSwitchPrompts: shouldUseLegacyInProgressSideSwitchPrompts ? true : setup.sideSwitchPrompts,
     sides: setup.sides
   };
 

--- a/src/lib/current-match/persistence.ts
+++ b/src/lib/current-match/persistence.ts
@@ -227,8 +227,7 @@ function parseMatchSetup(
   const shouldUseLegacySuperTiebreakTarget =
     isInProgress &&
     options?.legacyInProgressSuperTiebreakTargetPoints === legacySuperTiebreakTargetPoints;
-  const shouldUseLegacyInProgressSideSwitchPrompts =
-    isInProgress && typeof setup.sideSwitchPrompts === 'undefined';
+  const shouldUseLegacySideSwitchPrompts = typeof setup.sideSwitchPrompts === 'undefined';
 
   const setupInput = {
     format: setup.format,
@@ -255,7 +254,7 @@ function parseMatchSetup(
     superTiebreakTargetPoints: isSuperTiebreakTargetPoints(setup.superTiebreakTargetPoints)
       ? setup.superTiebreakTargetPoints
       : undefined,
-    sideSwitchPrompts: shouldUseLegacyInProgressSideSwitchPrompts ? true : setup.sideSwitchPrompts,
+    sideSwitchPrompts: shouldUseLegacySideSwitchPrompts ? true : setup.sideSwitchPrompts,
     sides: setup.sides
   };
 

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -326,7 +326,7 @@ export default {
       label: 'Current Set',
       setLabel: 'Set {{number}}',
       currentShort: 'Current',
-      currentSetScoreHeadline: 'Sets: {{team1}} - {{team2}}',
+      overallSetsScoreHeadline: 'Sets: {{team1}} - {{team2}}',
       openHistoryLabel: 'Open sets history. Current set score: {{team1}} - {{team2}}',
       emptyHistory: 'No completed sets yet.',
       superTiebreakBadge: 'ST'

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -230,6 +230,8 @@ export default {
       },
       sideSwitch: 'Side-switch Prompts',
       sideSwitchHint: 'Prompt players for court side changes',
+      autoOpenSetsHistoryModal: 'Auto-open Sets History',
+      autoOpenSetsHistoryModalHint: 'Automatically open sets history after each completed set',
       servingIndicator: 'Serving Indicator',
       servingIndicatorHint: 'Show who is currently serving',
       countdownTimer: 'Countdown Timer',
@@ -321,9 +323,12 @@ export default {
       sideSwitchOff: 'Side-switch prompts: off'
     },
     sets: {
-      label: 'Sets',
+      label: 'Current Set',
       setLabel: 'Set {{number}}',
       currentShort: 'Current',
+      currentSetScoreHeadline: 'Sets: {{team1}} - {{team2}}',
+      openHistoryLabel: 'Open sets history. Current set score: {{team1}} - {{team2}}',
+      emptyHistory: 'No completed sets yet.',
       superTiebreakBadge: 'ST'
     },
     timer: {

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -330,7 +330,7 @@ export default {
       setLabel: 'Set {{number}}',
       currentShort: 'Actual',
       overallSetsScoreHeadline: 'Sets: {{team1}} - {{team2}}',
-      openHistoryLabel: 'Abrir historial de sets. Marcador de sets: {{team1}} - {{team2}}',
+      openHistoryLabel: 'Abrir historial de sets. Marcador del set actual: {{team1}} - {{team2}}',
       emptyHistory: 'Todavía no hay sets completados.',
       superTiebreakBadge: 'ST'
     },

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -329,7 +329,7 @@ export default {
       label: 'Set Actual',
       setLabel: 'Set {{number}}',
       currentShort: 'Actual',
-      currentSetScoreHeadline: 'Sets: {{team1}} - {{team2}}',
+      overallSetsScoreHeadline: 'Sets: {{team1}} - {{team2}}',
       openHistoryLabel: 'Abrir historial de sets. Marcador de sets: {{team1}} - {{team2}}',
       emptyHistory: 'Todavía no hay sets completados.',
       superTiebreakBadge: 'ST'

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -231,6 +231,9 @@ export default {
       },
       sideSwitch: 'Avisos de Cambio de Lado',
       sideSwitchHint: 'Recordar a jugadores cambiar de lado',
+      autoOpenSetsHistoryModal: 'Autoabrir Historial de Sets',
+      autoOpenSetsHistoryModalHint:
+        'Abre automáticamente el historial de sets al completar cada set',
       servingIndicator: 'Indicador de servicio',
       servingIndicatorHint: 'Muestra quién está sacando actualmente',
       countdownTimer: 'Temporizador regresivo',
@@ -323,9 +326,12 @@ export default {
       sideSwitchOff: 'Cambios de lado: desactivado'
     },
     sets: {
-      label: 'Sets',
+      label: 'Set Actual',
       setLabel: 'Set {{number}}',
       currentShort: 'Actual',
+      currentSetScoreHeadline: 'Sets: {{team1}} - {{team2}}',
+      openHistoryLabel: 'Abrir historial de sets. Marcador de sets: {{team1}} - {{team2}}',
+      emptyHistory: 'Todavía no hay sets completados.',
       superTiebreakBadge: 'ST'
     },
     timer: {

--- a/src/lib/i18n/locales/pt.ts
+++ b/src/lib/i18n/locales/pt.ts
@@ -232,6 +232,9 @@ export default {
       },
       sideSwitch: 'Avisos de Troca de Lado',
       sideSwitchHint: 'Lembrar jogadores de trocar de lado',
+      autoOpenSetsHistoryModal: 'Autoabrir Histórico de Sets',
+      autoOpenSetsHistoryModalHint:
+        'Abre automaticamente o histórico de sets ao completar cada set',
       servingIndicator: 'Indicador de saque',
       servingIndicatorHint: 'Mostra quem está sacando no momento',
       countdownTimer: 'Cronômetro regressivo',
@@ -323,9 +326,12 @@ export default {
       sideSwitchOff: 'Trocas de lado: desativado'
     },
     sets: {
-      label: 'Sets',
+      label: 'Set Atual',
       setLabel: 'Set {{number}}',
       currentShort: 'Atual',
+      currentSetScoreHeadline: 'Sets: {{team1}} - {{team2}}',
+      openHistoryLabel: 'Abrir histórico de sets. Placar de sets: {{team1}} - {{team2}}',
+      emptyHistory: 'Ainda não há sets concluídos.',
       superTiebreakBadge: 'S-TB'
     },
     timer: {

--- a/src/lib/i18n/locales/pt.ts
+++ b/src/lib/i18n/locales/pt.ts
@@ -329,7 +329,7 @@ export default {
       label: 'Set Atual',
       setLabel: 'Set {{number}}',
       currentShort: 'Atual',
-      currentSetScoreHeadline: 'Sets: {{team1}} - {{team2}}',
+      overallSetsScoreHeadline: 'Sets: {{team1}} - {{team2}}',
       openHistoryLabel: 'Abrir histórico de sets. Placar de sets: {{team1}} - {{team2}}',
       emptyHistory: 'Ainda não há sets concluídos.',
       superTiebreakBadge: 'S-TB'

--- a/src/lib/i18n/locales/pt.ts
+++ b/src/lib/i18n/locales/pt.ts
@@ -330,7 +330,7 @@ export default {
       setLabel: 'Set {{number}}',
       currentShort: 'Atual',
       overallSetsScoreHeadline: 'Sets: {{team1}} - {{team2}}',
-      openHistoryLabel: 'Abrir histórico de sets. Placar de sets: {{team1}} - {{team2}}',
+      openHistoryLabel: 'Abrir histórico de sets. Placar do set atual: {{team1}} - {{team2}}',
       emptyHistory: 'Ainda não há sets concluídos.',
       superTiebreakBadge: 'S-TB'
     },

--- a/src/lib/setup/setup-storage.ts
+++ b/src/lib/setup/setup-storage.ts
@@ -54,6 +54,7 @@ export interface SetupPreferences {
   servingIndicatorEnabled: boolean;
   countdownTimerEnabled: boolean;
   countdownTimerDuration: CountdownTimerDuration;
+  autoOpenSetsHistoryModal?: boolean;
   sideSwitchPrompts: boolean;
   format: MatchFormat;
   gameMode: MatchGameMode;
@@ -95,7 +96,8 @@ export const defaultSetupPreferences: SetupPreferences = {
   servingIndicatorEnabled: defaultServingIndicatorEnabled,
   countdownTimerEnabled: defaultCountdownTimerEnabled,
   countdownTimerDuration: defaultCountdownTimerDuration,
-  sideSwitchPrompts: true,
+  autoOpenSetsHistoryModal: true,
+  sideSwitchPrompts: false,
   format: defaultMatchFormat,
   gameMode: defaultGameMode,
   decidingSetSuperTiebreak: false,
@@ -255,6 +257,8 @@ function toSetupPreferences(record: StoredSetupPreferences): SetupPreferences {
     servingIndicatorEnabled: record.servingIndicatorEnabled,
     countdownTimerEnabled: record.countdownTimerEnabled,
     countdownTimerDuration: record.countdownTimerDuration,
+    autoOpenSetsHistoryModal:
+      typeof record.autoOpenSetsHistoryModal === 'boolean' ? record.autoOpenSetsHistoryModal : true,
     sideSwitchPrompts: record.sideSwitchPrompts,
     format: record.format,
     gameMode: record.gameMode,
@@ -445,6 +449,11 @@ function parseStoredSetupPreferences(value: unknown): StoredSetupPreferences | n
     return null;
   }
 
+  const autoOpenSetsHistoryModal =
+    typeof candidate.autoOpenSetsHistoryModal === 'boolean'
+      ? candidate.autoOpenSetsHistoryModal
+      : true;
+
   if (!isMatchGameMode(candidate.gameMode)) {
     return null;
   }
@@ -485,6 +494,7 @@ function parseStoredSetupPreferences(value: unknown): StoredSetupPreferences | n
     servingIndicatorEnabled: candidate.servingIndicatorEnabled,
     countdownTimerEnabled: candidate.countdownTimerEnabled,
     countdownTimerDuration: candidate.countdownTimerDuration,
+    autoOpenSetsHistoryModal,
     sideSwitchPrompts: candidate.sideSwitchPrompts,
     format,
     gameMode: candidate.gameMode,

--- a/test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx
+++ b/test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx
@@ -14,6 +14,7 @@ import {
 
 import {
   createTestSetup,
+  reachSixAll,
   scorePoints,
   winQuickGame,
   winQuickSet
@@ -230,6 +231,248 @@ describe('ActiveMatchScreen', () => {
 
     await expect.element(screen.getByTestId('sets-card')).toBeInTheDocument();
     expect(screen.container.querySelector('[data-testid="info-card"]')).toBeNull();
+  });
+
+  test('opens sets history modal manually from sets card', async () => {
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={[]}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    await screen.getByTestId('sets-card').click();
+
+    await expect.element(screen.getByTestId('sets-history-modal')).toBeInTheDocument();
+    await expect.element(screen.getByRole('heading', { name: /0\s*-\s*0/ })).toBeInTheDocument();
+  });
+
+  test('auto-opens sets history modal when a set completes', async () => {
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={[
+          ...Array.from({ length: 5 }, () => winQuickGame('team-1')).flat(),
+          ...scorePoints('team-1', 'team-1', 'team-1')
+        ]}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    expect(screen.container.querySelector('[data-testid="sets-history-modal"]')).toBeNull();
+
+    await screen.getByTestId('team-panel-team-1').click();
+
+    await vi.waitFor(() => {
+      expect(screen.container.querySelector('[data-testid="sets-history-modal"]')).not.toBeNull();
+    });
+
+    await expect.element(screen.getByRole('heading', { name: /1\s*-\s*0/ })).toBeInTheDocument();
+  });
+
+  test('does not auto-open sets history modal when setup disables auto-open', async () => {
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup({ autoOpenSetsHistoryModal: false })}
+        initialActions={[
+          ...Array.from({ length: 5 }, () => winQuickGame('team-1')).flat(),
+          ...scorePoints('team-1', 'team-1', 'team-1')
+        ]}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    await screen.getByTestId('team-panel-team-1').click();
+
+    await vi.waitFor(() => {
+      expect(readDisplayedScore(screen, 'team-1')).toBe('0');
+    });
+    expect(screen.container.querySelector('[data-testid="sets-history-modal"]')).toBeNull();
+  });
+
+  test('does not auto-open sets history modal on regular point updates', async () => {
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={[]}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    await screen.getByTestId('team-panel-team-1').click();
+
+    await vi.waitFor(() => {
+      expect(readDisplayedScore(screen, 'team-1')).toBe('15');
+    });
+    expect(screen.container.querySelector('[data-testid="sets-history-modal"]')).toBeNull();
+  });
+
+  test('does not auto-open sets history modal when only a game completes', async () => {
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={scorePoints('team-1', 'team-1', 'team-1')}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    await screen.getByTestId('team-panel-team-1').click();
+
+    await vi.waitFor(() => {
+      expect(readDisplayedScore(screen, 'team-1')).toBe('0');
+    });
+    expect(screen.container.querySelector('[data-testid="sets-history-modal"]')).toBeNull();
+  });
+
+  test('does not auto-open sets history modal on intermediate tiebreak points', async () => {
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={reachSixAll()}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    await screen.getByTestId('team-panel-team-1').click();
+
+    await vi.waitFor(() => {
+      expect(readDisplayedScore(screen, 'team-1')).toBe('1');
+    });
+    expect(screen.container.querySelector('[data-testid="sets-history-modal"]')).toBeNull();
+  });
+
+  test('auto-opens sets history modal again after undo/correction returns to set boundary', async () => {
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={[
+          ...Array.from({ length: 5 }, () => winQuickGame('team-1')).flat(),
+          ...scorePoints('team-1', 'team-1', 'team-1')
+        ]}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    await screen.getByTestId('team-panel-team-1').click();
+    await vi.waitFor(() => {
+      expect(screen.container.querySelector('[data-testid="sets-history-modal"]')).not.toBeNull();
+    });
+
+    await screen.getByTestId('sets-history-modal-close').click();
+    await vi.waitFor(() => {
+      expect(screen.container.querySelector('[data-testid="sets-history-modal"]')).toBeNull();
+    });
+
+    await screen.getByTestId('revert-button-team-1').click();
+    await vi.waitFor(() => {
+      expect(readDisplayedScore(screen, 'team-1')).toBe('40');
+    });
+
+    await screen.getByTestId('team-panel-team-1').click();
+
+    await vi.waitFor(() => {
+      expect(screen.container.querySelector('[data-testid="sets-history-modal"]')).not.toBeNull();
+    });
+  });
+
+  test('auto-closes sets history modal after 30 seconds', async () => {
+    vi.useFakeTimers();
+
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={[]}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    await screen.getByTestId('sets-card').click();
+    await expect.element(screen.getByTestId('sets-history-modal')).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(29999);
+    await expect.element(screen.getByTestId('sets-history-modal')).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.waitFor(() => {
+      expect(screen.container.querySelector('[data-testid="sets-history-modal"]')).toBeNull();
+    });
+  });
+
+  test('close and reopen resets sets history auto-close countdown', async () => {
+    vi.useFakeTimers();
+
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={[
+          ...Array.from({ length: 5 }, () => winQuickGame('team-1')).flat(),
+          ...scorePoints('team-1', 'team-1', 'team-1')
+        ]}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    await screen.getByTestId('team-panel-team-1').click();
+    await vi.waitFor(() => {
+      expect(screen.container.querySelector('[data-testid="sets-history-modal"]')).not.toBeNull();
+    });
+
+    await expect.element(screen.getByTestId('sets-history-modal')).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(29000);
+    await screen.getByTestId('sets-history-modal-close').click();
+    await vi.waitFor(() => {
+      expect(screen.container.querySelector('[data-testid="sets-history-modal"]')).toBeNull();
+    });
+    await screen.getByTestId('sets-card').click();
+
+    await vi.advanceTimersByTimeAsync(1500);
+    await expect.element(screen.getByTestId('sets-history-modal')).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(28500);
+    await vi.waitFor(() => {
+      expect(screen.container.querySelector('[data-testid="sets-history-modal"]')).toBeNull();
+    });
+  });
+
+  test('keeps immediate finish navigation without waiting for sets history modal timeout', async () => {
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup()}
+        initialActions={[
+          ...winQuickSet('team-1'),
+          ...Array.from({ length: 5 }, () => winQuickGame('team-1')).flat(),
+          ...scorePoints('team-1', 'team-1', 'team-1')
+        ]}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    expect(screen.container.querySelector('[data-testid="sets-history-modal"]')).toBeNull();
+
+    await screen.getByTestId('team-panel-team-1').click();
+
+    await vi.waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: '/match/finish/$id',
+          params: { id: 'test-match' },
+          replace: true
+        })
+      );
+    });
+    expect(screen.container.querySelector('[data-testid="sets-history-modal"]')).toBeNull();
   });
 
   test('renders time chip', async () => {

--- a/test/components/ActiveMatchScreen/SetsCard.browser.test.tsx
+++ b/test/components/ActiveMatchScreen/SetsCard.browser.test.tsx
@@ -1,105 +1,115 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 
 import { SetsCard } from '@/components/ActiveMatchScreen/SetsCard/SetsCard';
+import type { MatchSetState } from '@/core/match/types';
 import { createTestSetup, winQuickSet } from '../../core/match/test-helpers';
 import { projectMatch } from '@/core/match/replay';
 
 describe('SetsCard', () => {
-  test('renders with label', async () => {
+  test('renders card as accessible button trigger with score context', async () => {
     const setup = createTestSetup();
     const projection = projectMatch(setup, []);
-    const sets = projection.state.sets;
+    const onOpenHistory = vi.fn<() => void>();
 
-    const screen = await render(<SetsCard sets={sets} currentSetIndex={0} />);
+    const screen = await render(
+      <SetsCard sets={projection.state.sets} currentSetIndex={0} onOpenHistory={onOpenHistory} />
+    );
 
-    await expect.element(screen.getByText('Sets')).toBeInTheDocument();
+    const button = screen.getByRole('button', {
+      name: /open sets history\. current set score: 0 - 0/i
+    });
+    await expect.element(button).toBeInTheDocument();
+    await expect.element(screen.getByText('Current Set')).toBeInTheDocument();
+    expect(button.element().querySelector('button')).toBeNull();
+    expect(button.element().querySelector('div')).toBeNull();
+
+    button.element().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onOpenHistory).toHaveBeenCalledTimes(1);
   });
 
-  test('renders first set correctly', async () => {
-    const setup = createTestSetup();
-    const projection = projectMatch(setup, []);
-    const sets = projection.state.sets;
-
-    const screen = await render(<SetsCard sets={sets} currentSetIndex={0} />);
-
-    // First set should show 0-0
-    await expect.element(screen.getByTestId('set-row-0')).toBeInTheDocument();
-    await expect.element(screen.getByTestId('set-row-0')).toHaveTextContent('Current');
-    await expect.element(screen.getByTestId('set-row-0')).toHaveTextContent('0-0');
-  });
-
-  test('renders fixed set labels from the Pencil design', async () => {
+  test('renders only current set row and score', async () => {
     const setup = createTestSetup();
     const actions = [...winQuickSet('team-1'), ...winQuickSet('team-2')];
     const projection = projectMatch(setup, actions);
-    const sets = projection.state.sets;
 
-    const screen = await render(<SetsCard sets={sets} currentSetIndex={2} />);
+    const screen = await render(<SetsCard sets={projection.state.sets} currentSetIndex={2} />);
 
-    await expect.element(screen.getByTestId('set-number-0')).toHaveTextContent('Set 1');
-    await expect.element(screen.getByTestId('set-number-1')).toHaveTextContent('Set 2');
-    await expect.element(screen.getByTestId('set-number-2')).toHaveTextContent('Current');
+    await expect.element(screen.getByTestId('set-row-current')).toBeInTheDocument();
+    await expect.element(screen.getByTestId('set-score-current')).toHaveTextContent('0-0');
+
+    expect(screen.container.querySelector('[data-testid="set-row-0"]')).toBeNull();
+    expect(screen.container.querySelector('[data-testid="set-number-current"]')).toBeNull();
   });
 
-  test('does not show a winner indicator for completed sets', async () => {
-    const setup = createTestSetup();
-    const actions = winQuickSet('team-1');
-    const projection = projectMatch(setup, actions);
-    const sets = projection.state.sets;
-
-    const screen = await render(<SetsCard sets={sets} currentSetIndex={1} />);
-
-    // First set should be completed with winner indicator
-    const firstSetRow = screen.getByTestId('set-row-0');
-    await expect.element(firstSetRow).toBeInTheDocument();
-
-    const winnerIndicator = screen.container.querySelector('[aria-label="Set winner"]');
-    expect(winnerIndicator).toBeNull();
-  });
-
-  test('shows games for both teams', async () => {
+  test('keeps stable sets-card test id', async () => {
     const setup = createTestSetup();
     const projection = projectMatch(setup, []);
-    const sets = projection.state.sets;
-
-    const screen = await render(<SetsCard sets={sets} currentSetIndex={0} />);
-
-    const setRow = screen.getByTestId('set-row-0');
-    await expect.element(setRow).toHaveTextContent('0-0');
-  });
-
-  test('has test id', async () => {
-    const setup = createTestSetup();
-    const projection = projectMatch(setup, []);
-    const sets = projection.state.sets;
-
-    const screen = await render(<SetsCard sets={sets} currentSetIndex={0} />);
+    const screen = await render(<SetsCard sets={projection.state.sets} currentSetIndex={0} />);
 
     await expect.element(screen.getByTestId('sets-card')).toBeInTheDocument();
   });
 
-  test('handles null currentSetIndex', async () => {
+  test('renders non-interactive fallback when onOpenHistory is absent', async () => {
     const setup = createTestSetup();
     const projection = projectMatch(setup, []);
-    const sets = projection.state.sets;
+
+    const screen = await render(<SetsCard sets={projection.state.sets} currentSetIndex={0} />);
+
+    await expect.element(screen.getByTestId('sets-card')).toBeInTheDocument();
+    await expect.element(screen.getByText('Current Set')).toBeInTheDocument();
+    expect(screen.container.querySelector('button[data-testid="sets-card"]')).toBeNull();
+    expect(screen.container.querySelector('[data-testid="sets-card"]')?.tagName).toBe('DIV');
+  });
+
+  test('falls back to latest set when currentSetIndex is null', async () => {
+    const sets: MatchSetState[] = [
+      {
+        index: 1,
+        mode: 'standard',
+        firstServer: 'team-1',
+        completed: true,
+        winner: 'team-1',
+        games: { 'team-1': 6, 'team-2': 4 },
+        tiebreakPoints: null
+      },
+      {
+        index: 2,
+        mode: 'standard',
+        firstServer: 'team-2',
+        completed: false,
+        games: { 'team-1': 3, 'team-2': 2 },
+        game: {
+          kind: 'standard',
+          points: { 'team-1': 0, 'team-2': 0 },
+          advantageTeam: null
+        }
+      }
+    ];
 
     const screen = await render(<SetsCard sets={sets} currentSetIndex={null} />);
 
-    // Should still render sets
-    await expect.element(screen.getByTestId('sets-card')).toBeInTheDocument();
+    await expect.element(screen.getByTestId('set-score-current')).toHaveTextContent('3-2');
   });
 
-  test('displays set numbers correctly', async () => {
-    const setup = createTestSetup();
-    const actions = [...winQuickSet('team-1'), ...winQuickSet('team-2')];
-    const projection = projectMatch(setup, actions);
-    const sets = projection.state.sets;
+  test('shows active super tiebreak points instead of games', async () => {
+    const sets: MatchSetState[] = [
+      {
+        index: 1,
+        mode: 'super-tiebreak',
+        firstServer: 'team-1',
+        completed: false,
+        games: { 'team-1': 0, 'team-2': 0 },
+        game: {
+          kind: 'tiebreak',
+          targetPoints: 11,
+          points: { 'team-1': 8, 'team-2': 7 }
+        }
+      }
+    ];
 
-    const screen = await render(<SetsCard sets={sets} currentSetIndex={2} />);
+    const screen = await render(<SetsCard sets={sets} currentSetIndex={0} />);
 
-    await expect.element(screen.getByTestId('set-number-0')).toHaveTextContent('Set 1');
-    await expect.element(screen.getByTestId('set-number-1')).toHaveTextContent('Set 2');
-    await expect.element(screen.getByTestId('set-number-2')).toHaveTextContent('Current');
+    await expect.element(screen.getByTestId('set-score-current')).toHaveTextContent('8-7');
   });
 });

--- a/test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx
+++ b/test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 
 import { SetsHistoryModal } from '@/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal';
@@ -39,6 +39,9 @@ const sets: MatchSetState[] = [
 ];
 
 describe('SetsHistoryModal', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
   test('renders dialog, headline and completed set history only', async () => {
     const onClose = vi.fn<() => void>();
     const screen = await render(

--- a/test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx
+++ b/test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx
@@ -1,0 +1,138 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+
+import { SetsHistoryModal } from '@/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal';
+import type { MatchSetState } from '@/core/match/types';
+import en from '@/lib/i18n/locales/en';
+
+const sets: MatchSetState[] = [
+  {
+    index: 1,
+    mode: 'standard',
+    firstServer: 'team-1',
+    completed: true,
+    winner: 'team-1',
+    games: { 'team-1': 6, 'team-2': 4 },
+    tiebreakPoints: null
+  },
+  {
+    index: 2,
+    mode: 'standard',
+    firstServer: 'team-2',
+    completed: true,
+    winner: 'team-2',
+    games: { 'team-1': 3, 'team-2': 6 },
+    tiebreakPoints: null
+  },
+  {
+    index: 3,
+    mode: 'super-tiebreak',
+    firstServer: 'team-1',
+    completed: false,
+    games: { 'team-1': 0, 'team-2': 0 },
+    game: {
+      kind: 'tiebreak',
+      targetPoints: 11,
+      points: { 'team-1': 8, 'team-2': 7 }
+    }
+  }
+];
+
+describe('SetsHistoryModal', () => {
+  test('renders dialog, headline and completed set history only', async () => {
+    const onClose = vi.fn<() => void>();
+    const screen = await render(
+      <SetsHistoryModal isOpen openToken={1} sets={sets} onClose={onClose} />
+    );
+
+    await expect.element(screen.getByRole('dialog')).toBeInTheDocument();
+    await expect.element(screen.getByTestId('sets-history-modal')).toBeInTheDocument();
+    await expect.element(screen.getByRole('heading', { name: /1 - 1/ })).toBeInTheDocument();
+    await expect.element(screen.getByText('Set 1')).toBeInTheDocument();
+    await expect.element(screen.getByText('Set 2')).toBeInTheDocument();
+    await expect.element(screen.getByText('6 - 4')).toBeInTheDocument();
+    await expect.element(screen.getByText('3 - 6')).toBeInTheDocument();
+    await expect.element(screen.getByText('Set 3')).not.toBeInTheDocument();
+    await expect.element(screen.getByText('8 - 7')).not.toBeInTheDocument();
+  });
+
+  test('close button is accessible and closes modal', async () => {
+    const onClose = vi.fn<() => void>();
+    const screen = await render(
+      <SetsHistoryModal isOpen openToken={1} sets={sets} onClose={onClose} />
+    );
+
+    const closeButton = screen.getByRole('button', { name: en.common.close });
+    await expect.element(closeButton).toBeInTheDocument();
+
+    await closeButton.click();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders modal semantics with focus inside dialog', async () => {
+    const onClose = vi.fn<() => void>();
+    const screen = await render(
+      <SetsHistoryModal isOpen openToken={1} sets={sets} onClose={onClose} />
+    );
+
+    const dialog = screen.getByRole('dialog').element();
+    const closeButton = screen.getByRole('button', { name: en.common.close }).element();
+
+    await expect.element(screen.getByRole('dialog')).toBeInTheDocument();
+    await vi.waitFor(() => {
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+    closeButton.focus();
+    expect(dialog.contains(document.activeElement)).toBe(true);
+  });
+
+  test('resets auto-close timer when openToken changes while open', async () => {
+    vi.useFakeTimers();
+
+    const onClose = vi.fn<() => void>();
+    const screen = await render(
+      <SetsHistoryModal isOpen openToken={1} sets={sets} onClose={onClose} />
+    );
+
+    await expect.element(screen.getByTestId('sets-history-modal')).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(29000);
+    await screen.rerender(<SetsHistoryModal isOpen openToken={2} sets={sets} onClose={onClose} />);
+
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(onClose).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(28500);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders localized empty state when no completed sets exist', async () => {
+    const onClose = vi.fn<() => void>();
+    const screen = await render(
+      <SetsHistoryModal
+        isOpen
+        openToken={1}
+        sets={[
+          {
+            index: 1,
+            mode: 'standard',
+            firstServer: 'team-1',
+            completed: false,
+            games: { 'team-1': 1, 'team-2': 1 },
+            game: {
+              kind: 'standard',
+              points: { 'team-1': 0, 'team-2': 0 },
+              advantageTeam: null
+            }
+          }
+        ]}
+        onClose={onClose}
+      />
+    );
+
+    await expect
+      .element(screen.getByTestId('sets-history-modal-empty-state'))
+      .toHaveTextContent(en.match.sets.emptyHistory);
+    await expect.element(screen.getByTestId('sets-history-modal-list')).not.toBeInTheDocument();
+  });
+});

--- a/test/components/ActiveMatchScreen/sets-history.test.ts
+++ b/test/components/ActiveMatchScreen/sets-history.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  getSetDisplayScore,
+  getSetsHistoryAutoOpenSignature,
+  getSetsWonScore
+} from '@/components/ActiveMatchScreen/sets-history';
+import type { MatchSetState } from '@/core/match/types';
+
+describe('sets-history display score', () => {
+  test('uses tiebreak points for completed super-tiebreak sets when available', () => {
+    const set: MatchSetState = {
+      index: 3,
+      mode: 'super-tiebreak',
+      firstServer: 'team-1',
+      completed: true,
+      winner: 'team-1',
+      games: { 'team-1': 0, 'team-2': 0 },
+      tiebreakPoints: { 'team-1': 11, 'team-2': 9 }
+    };
+
+    expect(getSetDisplayScore(set)).toEqual({ 'team-1': 11, 'team-2': 9 });
+  });
+
+  test('uses legacy final tiebreak game points when completed super-tiebreak has null tiebreakPoints', () => {
+    const setWithLegacyGameShape = {
+      index: 3,
+      mode: 'super-tiebreak',
+      firstServer: 'team-1',
+      completed: true,
+      winner: 'team-1',
+      games: { 'team-1': 0, 'team-2': 0 },
+      tiebreakPoints: null,
+      game: {
+        kind: 'tiebreak',
+        points: { 'team-1': 12, 'team-2': 10 }
+      }
+    } as MatchSetState;
+
+    expect(getSetDisplayScore(setWithLegacyGameShape)).toEqual({ 'team-1': 12, 'team-2': 10 });
+  });
+
+  test('falls back to set games when completed super-tiebreak has no recoverable tiebreak score', () => {
+    const set: MatchSetState = {
+      index: 3,
+      mode: 'super-tiebreak',
+      firstServer: 'team-1',
+      completed: true,
+      winner: 'team-1',
+      games: { 'team-1': 1, 'team-2': 0 },
+      tiebreakPoints: null
+    };
+
+    expect(getSetDisplayScore(set)).toEqual({ 'team-1': 1, 'team-2': 0 });
+  });
+});
+
+describe('sets-history aggregate score', () => {
+  test('counts completed sets won by each team', () => {
+    const sets: MatchSetState[] = [
+      {
+        index: 1,
+        mode: 'standard',
+        firstServer: 'team-1',
+        completed: true,
+        winner: 'team-1',
+        games: { 'team-1': 6, 'team-2': 4 },
+        tiebreakPoints: null
+      },
+      {
+        index: 2,
+        mode: 'standard',
+        firstServer: 'team-2',
+        completed: true,
+        winner: 'team-2',
+        games: { 'team-1': 3, 'team-2': 6 },
+        tiebreakPoints: null
+      },
+      {
+        index: 3,
+        mode: 'super-tiebreak',
+        firstServer: 'team-1',
+        completed: false,
+        games: { 'team-1': 0, 'team-2': 0 },
+        game: {
+          kind: 'tiebreak',
+          targetPoints: 11,
+          points: { 'team-1': 8, 'team-2': 7 }
+        }
+      }
+    ];
+
+    expect(getSetsWonScore(sets)).toEqual({ 'team-1': 1, 'team-2': 1 });
+  });
+});
+
+describe('sets-history auto-open signature', () => {
+  test('changes only when completed sets change', () => {
+    const baseSets: MatchSetState[] = [
+      {
+        index: 1,
+        mode: 'standard',
+        firstServer: 'team-1',
+        completed: false,
+        games: { 'team-1': 3, 'team-2': 2 },
+        game: {
+          kind: 'standard',
+          points: { 'team-1': 30, 'team-2': 30 },
+          advantageTeam: null
+        }
+      }
+    ];
+
+    const sameCompletedButDifferentGameProgress: MatchSetState[] = [
+      {
+        index: 1,
+        mode: 'standard',
+        firstServer: 'team-1',
+        completed: false,
+        games: { 'team-1': 4, 'team-2': 2 },
+        game: {
+          kind: 'standard',
+          points: { 'team-1': 30, 'team-2': 30 },
+          advantageTeam: null
+        }
+      }
+    ];
+
+    const afterSetCompletion: MatchSetState[] = [
+      {
+        index: 1,
+        mode: 'standard',
+        firstServer: 'team-1',
+        completed: true,
+        winner: 'team-1',
+        games: { 'team-1': 6, 'team-2': 2 },
+        tiebreakPoints: null
+      }
+    ];
+
+    expect(getSetsHistoryAutoOpenSignature(baseSets)).toBe(
+      getSetsHistoryAutoOpenSignature(sameCompletedButDifferentGameProgress)
+    );
+    expect(getSetsHistoryAutoOpenSignature(baseSets)).not.toBe(
+      getSetsHistoryAutoOpenSignature(afterSetCompletion)
+    );
+  });
+});

--- a/test/components/SetupScreen/SetupScreen.browser.test.tsx
+++ b/test/components/SetupScreen/SetupScreen.browser.test.tsx
@@ -83,7 +83,8 @@ vi.mock('@/lib/setup/setup-storage', () => ({
     servingIndicatorEnabled: true,
     countdownTimerEnabled: false,
     countdownTimerDuration: 90,
-    sideSwitchPrompts: true,
+    autoOpenSetsHistoryModal: true,
+    sideSwitchPrompts: false,
     format: 'best-of-3',
     gameMode: 'advantage',
     decidingSetSuperTiebreak: false,
@@ -162,6 +163,20 @@ describe('SetupScreen', () => {
     await expect.element(audioAnnouncementsToggle).toHaveAttribute('aria-checked', 'true');
     expect(
       audioAnnouncementsToggle.element().compareDocumentPosition(goldenPointToggle.element()) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  test('shows auto-open sets history enabled by default before side-switch prompts', async () => {
+    const screen = await render(<SetupScreen />);
+
+    const autoOpenToggle = screen.getByRole('switch', { name: /auto-open sets history/i });
+    const sideSwitchToggle = screen.getByRole('switch', { name: /side-switch prompts/i });
+
+    await expect.element(autoOpenToggle).toHaveAttribute('aria-checked', 'true');
+    await expect.element(sideSwitchToggle).toHaveAttribute('aria-checked', 'false');
+    expect(
+      autoOpenToggle.element().compareDocumentPosition(sideSwitchToggle.element()) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
   });

--- a/test/components/SetupScreen/useSetupForm.browser.test.tsx
+++ b/test/components/SetupScreen/useSetupForm.browser.test.tsx
@@ -19,7 +19,8 @@ vi.mock('@/lib/setup/setup-storage', () => ({
     servingIndicatorEnabled: true,
     countdownTimerEnabled: false,
     countdownTimerDuration: 90,
-    sideSwitchPrompts: true,
+    autoOpenSetsHistoryModal: true,
+    sideSwitchPrompts: false,
     format: 'best-of-3',
     gameMode: 'advantage',
     decidingSetSuperTiebreak: false,
@@ -74,7 +75,8 @@ describe('useSetupForm', () => {
     expect(capturedState!.formData.servingIndicatorEnabled).toBe(true);
     expect(capturedState!.formData.countdownTimerEnabled).toBe(false);
     expect(capturedState!.formData.countdownTimerDuration).toBe(90);
-    expect(capturedState!.formData.sideSwitchPrompts).toBe(true);
+    expect(capturedState!.formData.autoOpenSetsHistoryModal).toBe(true);
+    expect(capturedState!.formData.sideSwitchPrompts).toBe(false);
   });
 
   test('initializes with empty errors', async () => {
@@ -130,6 +132,7 @@ describe('useSetupForm', () => {
       servingIndicatorEnabled: false,
       countdownTimerEnabled: true,
       countdownTimerDuration: 120,
+      autoOpenSetsHistoryModal: true,
       sideSwitchPrompts: false,
       format: 'best-of-5',
       gameMode: 'golden-point',
@@ -176,6 +179,7 @@ describe('useSetupForm', () => {
       servingIndicatorEnabled: true,
       countdownTimerEnabled: false,
       countdownTimerDuration: 90,
+      autoOpenSetsHistoryModal: true,
       sideSwitchPrompts: true,
       format: 'best-of-3',
       gameMode: 'advantage',
@@ -265,6 +269,7 @@ describe('useSetupForm', () => {
       expect(screen.getByTestId('state').element().textContent).toContain('"voiceName":null');
       expect(mockSaveSetupPreferenceSlice).not.toHaveBeenCalled();
 
+      await screen.getByTestId('update-side-switch-true').click();
       await screen.getByTestId('update-side-switch-false').click();
 
       await vi.waitFor(() => {
@@ -273,6 +278,7 @@ describe('useSetupForm', () => {
           servingIndicatorEnabled: true,
           countdownTimerEnabled: false,
           countdownTimerDuration: 90,
+          autoOpenSetsHistoryModal: true,
           sideSwitchPrompts: false,
           format: 'best-of-3',
           gameMode: 'advantage',
@@ -296,6 +302,7 @@ describe('useSetupForm', () => {
 
       await expect.element(screen.getByTestId('update-side-switch-false')).toBeInTheDocument();
 
+      await screen.getByTestId('update-side-switch-true').click();
       await screen.getByTestId('update-side-switch-false').click();
 
       await vi.waitFor(() => {
@@ -310,24 +317,14 @@ describe('useSetupForm', () => {
       await screen.getByTestId('update-side-switch-false').click();
 
       await vi.waitFor(() => {
-        expect(mockSaveSetupPreferenceSlice).toHaveBeenCalledTimes(2);
+        expect(mockSaveSetupPreferenceSlice).toHaveBeenCalledTimes(3);
       });
-      expect(mockSaveSetupPreferenceSlice).toHaveBeenNthCalledWith(1, {
+      expect(mockSaveSetupPreferenceSlice).toHaveBeenLastCalledWith({
         audioAnnouncementsEnabled: true,
         servingIndicatorEnabled: true,
         countdownTimerEnabled: false,
         countdownTimerDuration: 90,
-        sideSwitchPrompts: false,
-        format: 'best-of-3',
-        gameMode: 'advantage',
-        decidingSetSuperTiebreak: false,
-        superTiebreakTargetPoints: 11
-      });
-      expect(mockSaveSetupPreferenceSlice).toHaveBeenNthCalledWith(2, {
-        audioAnnouncementsEnabled: true,
-        servingIndicatorEnabled: true,
-        countdownTimerEnabled: false,
-        countdownTimerDuration: 90,
+        autoOpenSetsHistoryModal: true,
         sideSwitchPrompts: false,
         format: 'best-of-3',
         gameMode: 'advantage',
@@ -909,6 +906,7 @@ describe('useSetupForm interactions', () => {
         servingIndicatorEnabled: true,
         countdownTimerEnabled: false,
         countdownTimerDuration: 90,
+        autoOpenSetsHistoryModal: true,
         sideSwitchPrompts: false,
         format: 'best-of-3',
         gameMode: 'golden-point',
@@ -934,7 +932,8 @@ describe('useSetupForm interactions', () => {
         servingIndicatorEnabled: true,
         countdownTimerEnabled: false,
         countdownTimerDuration: 90,
-        sideSwitchPrompts: true,
+        autoOpenSetsHistoryModal: true,
+        sideSwitchPrompts: false,
         format: 'best-of-3',
         gameMode: 'advantage',
         decidingSetSuperTiebreak: false,

--- a/test/components/SetupScreen/validateSetupForm.test.ts
+++ b/test/components/SetupScreen/validateSetupForm.test.ts
@@ -17,6 +17,7 @@ describe('validateSetupForm', () => {
     servingIndicatorEnabled: true,
     countdownTimerEnabled: false,
     countdownTimerDuration: 90,
+    autoOpenSetsHistoryModal: true,
     sideSwitchPrompts: true
   };
 

--- a/test/current-match/indexed-db.browser.test.ts
+++ b/test/current-match/indexed-db.browser.test.ts
@@ -96,6 +96,7 @@ describe('current match IndexedDB persistence', () => {
       servingIndicatorEnabled: true,
       countdownTimerEnabled: false,
       countdownTimerDuration: 90,
+      autoOpenSetsHistoryModal: true,
       sideSwitchPrompts: true,
       format: 'best-of-3',
       gameMode: 'advantage',

--- a/test/current-match/persistence.test.ts
+++ b/test/current-match/persistence.test.ts
@@ -193,6 +193,31 @@ describe('current match persistence helpers', () => {
     expect(decodedRecord.setup.sideSwitchPrompts).toBe(true);
   });
 
+  test('preserves legacy completed side-switch prompts when persisted field is missing', () => {
+    const legacyCompletedRecordMissingSideSwitchPrompts = {
+      schemaVersion: currentMatchSchemaVersion,
+      matchId: testMatchId,
+      setup: {
+        format: 'best-of-3',
+        gameMode: 'advantage',
+        initialServer: 'team-1',
+        decidingSetSuperTiebreak: false,
+        sides: [
+          { id: 'team-1', playerNames: ['Ana', 'Bea'] },
+          { id: 'team-2', playerNames: ['Carla', 'Dani'] }
+        ]
+      },
+      actions: [],
+      startedAt: testStartedAt,
+      finishedAt: testFinishedAt
+    };
+
+    const decodedRecord = parseCurrentMatchRecord(legacyCompletedRecordMissingSideSwitchPrompts);
+
+    expect(decodedRecord.setup.sideSwitchPrompts).toBe(true);
+    expect(decodedRecord.finishedAt).toBe(testFinishedAt);
+  });
+
   test('preserves legacy in-progress target across save/resume cycles with explicit metadata', () => {
     const legacyRecord = {
       schemaVersion: currentMatchSchemaVersion,

--- a/test/current-match/persistence.test.ts
+++ b/test/current-match/persistence.test.ts
@@ -170,6 +170,29 @@ describe('current match persistence helpers', () => {
     );
   });
 
+  test('preserves legacy in-progress side-switch prompts when persisted field is missing', () => {
+    const legacyRecordMissingSideSwitchPrompts = {
+      schemaVersion: currentMatchSchemaVersion,
+      matchId: testMatchId,
+      setup: {
+        format: 'best-of-3',
+        gameMode: 'advantage',
+        initialServer: 'team-1',
+        decidingSetSuperTiebreak: false,
+        sides: [
+          { id: 'team-1', playerNames: ['Ana', 'Bea'] },
+          { id: 'team-2', playerNames: ['Carla', 'Dani'] }
+        ]
+      },
+      actions: [],
+      startedAt: testStartedAt
+    };
+
+    const decodedRecord = parseCurrentMatchRecord(legacyRecordMissingSideSwitchPrompts);
+
+    expect(decodedRecord.setup.sideSwitchPrompts).toBe(true);
+  });
+
   test('preserves legacy in-progress target across save/resume cycles with explicit metadata', () => {
     const legacyRecord = {
       schemaVersion: currentMatchSchemaVersion,

--- a/test/lib/setup/setup-storage.test.ts
+++ b/test/lib/setup/setup-storage.test.ts
@@ -32,6 +32,7 @@ describe('setup-storage', () => {
       servingIndicatorEnabled: false,
       countdownTimerEnabled: true,
       countdownTimerDuration: 120,
+      autoOpenSetsHistoryModal: true,
       sideSwitchPrompts: false,
       format: 'best-of-3',
       gameMode: 'golden-point',
@@ -67,6 +68,7 @@ describe('setup-storage', () => {
       servingIndicatorEnabled: false,
       countdownTimerEnabled: true,
       countdownTimerDuration: 60,
+      autoOpenSetsHistoryModal: true,
       sideSwitchPrompts: false,
       format: 'best-of-3',
       gameMode: 'golden-point',
@@ -91,6 +93,7 @@ describe('setup-storage', () => {
       servingIndicatorEnabled: false,
       countdownTimerEnabled: true,
       countdownTimerDuration: 60,
+      autoOpenSetsHistoryModal: true,
       sideSwitchPrompts: false,
       format: 'best-of-3',
       gameMode: 'golden-point',
@@ -107,6 +110,7 @@ describe('setup-storage', () => {
       servingIndicatorEnabled: false,
       countdownTimerEnabled: true,
       countdownTimerDuration: 60,
+      autoOpenSetsHistoryModal: true,
       sideSwitchPrompts: false,
       format: 'best-of-3',
       gameMode: 'golden-point',
@@ -350,7 +354,10 @@ describe('setup-storage', () => {
 
     const storage = createSetupStorage({ databaseName: 'legacy-setup-normalization-db' });
 
-    await expect(storage.loadSetupPreferences()).resolves.toEqual(defaultSetupPreferences);
+    await expect(storage.loadSetupPreferences()).resolves.toEqual({
+      ...defaultSetupPreferences,
+      sideSwitchPrompts: true
+    });
   });
 
   it('normalizes legacy setup records missing only super tiebreak target', async () => {


### PR DESCRIPTION
## Summary

Redesign the SetsCard into a compact current-score trigger and add a responsive SetsHistoryModal (Base UI Dialog) that surfaces completed-set details on demand.

## What was added

### Compact current-score SetsCard trigger
- Redesigned `SetsCard` to show only the live set score in a minimal, tappable card
- Removed inline set-by-set breakdown from the main match view to reduce visual clutter
- Card acts as a trigger button to open the full sets history

### SetsHistoryModal (Base UI Dialog)
- New `SetsHistoryModal` component built on Base UI `Dialog` for accessibility
- Responsive layout: adapts to mobile and desktop viewports
- Shows sets-score header (team vs team games per set) and completed-set history rows
- Accessible close via backdrop click, Escape key, and explicit close button

### Auto-open only on set completion
- Modal auto-opens when a set completes so players immediately see the result
- Does not auto-open on match load or during ongoing sets
- Controlled via a new `autoOpenOnSetComplete` flag

### Setup toggle for auto-open
- Added a toggle in `SetupScreen` to enable/disable auto-open behavior
- New `autoOpenSetsHistory` field in setup form and persisted configuration
- Default: enabled for new setups

### Side-switch default false for new setups with legacy fallback
- `sideSwitch` defaults to `false` for new setups (teams stay on same side)
- Legacy matches that already have `sideSwitch` defined retain their original value
- Backward-compatible migration via `setup-storage` and `persistence` layers

### i18n support
- Added translation keys in English, Spanish, and Portuguese for new UI strings

### Test and E2E updates
- Unit tests for `sets-history` utility module
- Browser tests for `SetsHistoryModal` component behavior
- Updated `SetsCard` browser tests for new compact design
- Updated `ActiveMatchScreen` browser tests for modal integration
- Updated `SetupScreen` and `useSetupForm` tests for new toggle and side-switch default
- Updated all E2E specs (`active-match`, `match-end`, `tiebreaks`, `undo`, `advantage-deuce`, `golden-point`, `persistence-recovery`, `responsive-layout`) and shared `match-flow` helper

## Test results
- ✅ 102 test files passed (1113 tests)
- ✅ Coverage thresholds met (88.99% statements, 80.72% branches, 88.86% functions, 89.42% lines)
- ✅ Pre-commit hooks passed (oxlint, stylelint, oxfmt)
- ✅ Pre-push hooks passed (vitest, coverage, PWA precache)