### PR TITLE
feat: add serving player indicator to active match display

### DIFF
--- a/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
+++ b/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
@@ -153,7 +153,7 @@ export function ActiveMatchScreen({
   const team2Name =
     resolvedTeam2Name === 'team-2' ? t('setup.firstServer.team2') : resolvedTeam2Name;
 
-  const { scoreDisplay, activeSetIndex, sideSwitch, servingTeam } = derived;
+  const { scoreDisplay, activeSetIndex, sideSwitch, servingTeam, servingPlayerNumber } = derived;
   const showServingIndicator = setup.servingIndicatorEnabled;
 
   useMatchAnnouncements({
@@ -501,6 +501,7 @@ export function ActiveMatchScreen({
               teamName={team1Name}
               score={getTeamScore('team-1')}
               isServing={servingTeam === 'team-1'}
+              servingPlayerNumber={servingTeam === 'team-1' ? servingPlayerNumber : null}
               showServingIndicator={showServingIndicator}
               onClick={handleScoreTeam1}
               disabled={isLoading || isMatchCompleted}
@@ -523,6 +524,7 @@ export function ActiveMatchScreen({
               teamName={team2Name}
               score={getTeamScore('team-2')}
               isServing={servingTeam === 'team-2'}
+              servingPlayerNumber={servingTeam === 'team-2' ? servingPlayerNumber : null}
               showServingIndicator={showServingIndicator}
               onClick={handleScoreTeam2}
               disabled={isLoading || isMatchCompleted}

--- a/src/components/ActiveMatchScreen/TeamPanel/TeamPanel.tsx
+++ b/src/components/ActiveMatchScreen/TeamPanel/TeamPanel.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils/cn';
 
-import type { MatchTeamId } from '@/core/match/types';
+import type { MatchServingPlayerNumber, MatchTeamId } from '@/core/match/types';
 
 import styles from './TeamPanel.module.css';
 
@@ -12,6 +12,7 @@ interface TeamPanelProps extends Omit<ComponentPropsWithoutRef<'button'>, 'onCli
   teamName: string;
   score: string;
   isServing: boolean;
+  servingPlayerNumber?: MatchServingPlayerNumber | null;
   showServingIndicator?: boolean;
   onClick: () => void;
 }
@@ -21,6 +22,7 @@ export function TeamPanel({
   teamName,
   score,
   isServing,
+  servingPlayerNumber = null,
   showServingIndicator = true,
   onClick,
   disabled = false,
@@ -30,6 +32,12 @@ export function TeamPanel({
   const { t } = useTranslation();
   const servingStatusId = useId();
   const shouldShowServing = isServing && showServingIndicator;
+  const servingLabel =
+    shouldShowServing && servingPlayerNumber !== null
+      ? t('match.servingPlayer', { number: servingPlayerNumber })
+      : t('match.serving');
+  const displayTeamName =
+    shouldShowServing && servingPlayerNumber !== null ? `${teamName} · ${servingLabel}` : teamName;
 
   const panelClass = teamId === 'team-1' ? styles.team1Panel : styles.team2Panel;
   const servingClass = shouldShowServing ? styles.serving : undefined;
@@ -46,13 +54,13 @@ export function TeamPanel({
       data-testid={`team-panel-${teamId}`}
       data-inactivity-ignore=""
     >
-      <span className={styles.teamName}>{teamName}</span>
+      <span className={styles.teamName}>{displayTeamName}</span>
       <span className={styles.score} aria-live="polite">
         {score}
       </span>
       {shouldShowServing && (
         <span id={servingStatusId} className={styles.srOnly}>
-          {t('match.serving')}
+          {servingLabel}
         </span>
       )}
     </button>

--- a/src/core/match/derived-state.ts
+++ b/src/core/match/derived-state.ts
@@ -3,6 +3,7 @@ import {
   type CompletedMatchSet,
   type MatchDerivedState,
   type MatchScoreDisplay,
+  type MatchServingPlayerNumber,
   type MatchSetup,
   type MatchSideSwitchState,
   type MatchState,
@@ -75,6 +76,90 @@ function getTiebreakServingTeam(openingServer: MatchTeamId, pointsPlayed: number
   return block % 2 === 0 ? getOpponentTeamId(openingServer) : openingServer;
 }
 
+function recordServiceTurn(counts: TeamScore<number>, teamId: MatchTeamId): void {
+  counts[teamId] += 1;
+}
+
+function recordStandardServiceTurns(
+  counts: TeamScore<number>,
+  firstServer: MatchTeamId,
+  completedGames: number
+): void {
+  for (let gameIndex = 0; gameIndex < completedGames; gameIndex += 1) {
+    recordServiceTurn(counts, toggleServer(firstServer, gameIndex));
+  }
+}
+
+function recordTiebreakServiceTurns(
+  counts: TeamScore<number>,
+  openingServer: MatchTeamId,
+  pointsPlayed: number,
+  includePartialLastTurn: boolean
+): void {
+  if (pointsPlayed <= 0) {
+    return;
+  }
+
+  let server = openingServer;
+  let remainingPoints = pointsPlayed;
+  let turnLength = 1;
+
+  while (remainingPoints > 0) {
+    if (!includePartialLastTurn && remainingPoints < turnLength) {
+      return;
+    }
+
+    recordServiceTurn(counts, server);
+    remainingPoints -= turnLength;
+    server = getOpponentTeamId(server);
+    turnLength = 2;
+  }
+}
+
+function getCompletedStandardGameCount(set: CompletedMatchSet): number {
+  if (set.tiebreakPoints === null) {
+    return getTotalScore(set.games);
+  }
+
+  return set.mode === 'super-tiebreak' ? 0 : 12;
+}
+
+function getServiceTurnCountsBeforeActiveTurn(state: MatchState): TeamScore<number> {
+  const counts = createTeamScore(0, 0);
+
+  for (const set of getCompletedSets(state)) {
+    recordStandardServiceTurns(counts, set.firstServer, getCompletedStandardGameCount(set));
+
+    if (set.tiebreakPoints !== null) {
+      recordTiebreakServiceTurns(
+        counts,
+        toggleServer(set.firstServer, getCompletedStandardGameCount(set)),
+        getTotalScore(set.tiebreakPoints),
+        true
+      );
+    }
+  }
+
+  const activeSet = getActiveSet(state);
+
+  if (!activeSet) {
+    return counts;
+  }
+
+  recordStandardServiceTurns(counts, activeSet.firstServer, getTotalScore(activeSet.games));
+
+  if (activeSet.game.kind === 'tiebreak') {
+    recordTiebreakServiceTurns(
+      counts,
+      getTiebreakOpeningServer(activeSet),
+      getTotalScore(activeSet.game.points),
+      false
+    );
+  }
+
+  return counts;
+}
+
 export function getServingTeam(state: MatchState): MatchTeamId | null {
   const activeSet = getActiveSet(state);
 
@@ -90,6 +175,23 @@ export function getServingTeam(state: MatchState): MatchTeamId | null {
     getTiebreakOpeningServer(activeSet),
     getTotalScore(activeSet.game.points)
   );
+}
+
+export function getServingPlayerNumber(state: MatchState): MatchServingPlayerNumber | null {
+  const servingTeam = getServingTeam(state);
+
+  return getServingPlayerNumberForTeam(state, servingTeam);
+}
+
+function getServingPlayerNumberForTeam(
+  state: MatchState,
+  servingTeam: MatchTeamId | null
+): MatchServingPlayerNumber | null {
+  if (servingTeam === null) {
+    return null;
+  }
+
+  return getServiceTurnCountsBeforeActiveTurn(state)[servingTeam] % 2 === 0 ? 1 : 2;
 }
 
 export function getNextSetFirstServer(set: CompletedMatchSet): MatchTeamId {
@@ -217,11 +319,13 @@ function getScoreDisplay(state: MatchState): MatchScoreDisplay {
 
 export function deriveMatchState(setup: MatchSetup, state: MatchState): MatchDerivedState {
   const winner = getMatchWinner(setup, state);
+  const servingTeam = getServingTeam(state);
 
   return {
     status: winner ? 'completed' : 'in-progress',
     activeSetIndex: getActiveSet(state)?.index ?? null,
-    servingTeam: getServingTeam(state),
+    servingTeam,
+    servingPlayerNumber: getServingPlayerNumberForTeam(state, servingTeam),
     winner,
     canContinuePlaying: winner !== null && setup.setCap !== null,
     setsWon: getSetsWon(state),

--- a/src/core/match/types.ts
+++ b/src/core/match/types.ts
@@ -9,6 +9,7 @@ export const superTiebreakTargetPointsOptions = [7, 9, 11] as const;
 export type MatchFormat = (typeof matchFormats)[number];
 export type MatchGameMode = (typeof gameModes)[number];
 export type MatchTeamId = (typeof matchTeamIds)[number];
+export type MatchServingPlayerNumber = 1 | 2;
 export type BestOfOneDecidingBehavior = (typeof bestOfOneDecidingBehaviors)[number];
 export type MatchSetMode = (typeof setModes)[number];
 export type CountdownTimerDuration = (typeof countdownTimerDurations)[number];
@@ -156,6 +157,7 @@ export interface MatchDerivedState {
   status: 'in-progress' | 'completed';
   activeSetIndex: number | null;
   servingTeam: MatchTeamId | null;
+  servingPlayerNumber: MatchServingPlayerNumber | null;
   winner: MatchWinner | null;
   canContinuePlaying: boolean;
   setsWon: TeamScore<number>;

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -312,6 +312,7 @@ export default {
     },
     scorePointFor: 'Score point for {{teamName}}',
     serving: 'Serving',
+    servingPlayer: 'Serving: Player {{number}}',
     info: {
       title: 'Court details',
       goldenPoint: 'GP',

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -315,6 +315,7 @@ export default {
     },
     scorePointFor: 'Anotar punto para {{teamName}}',
     serving: 'Sacando',
+    servingPlayer: 'Sacando: Jugador {{number}}',
     info: {
       title: 'Detalles de cancha',
       goldenPoint: 'PO',

--- a/src/lib/i18n/locales/pt.ts
+++ b/src/lib/i18n/locales/pt.ts
@@ -315,6 +315,7 @@ export default {
     },
     scorePointFor: 'Marcar ponto para {{teamName}}',
     serving: 'Sacando',
+    servingPlayer: 'Sacando: Jogador {{number}}',
     info: {
       title: 'Detalhes da quadra',
       goldenPoint: 'PO',

--- a/test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx
+++ b/test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx
@@ -540,6 +540,7 @@ describe('ActiveMatchScreen', () => {
     expect(getComputedStyle(team1Score as Element).color).toBe(
       resolveCssColor('color', 'var(--semantic-color-items-primary-content)')
     );
+    await expect.element(screen.getByText('Ana & Bea · Serving: Player 1')).toBeInTheDocument();
     await expect
       .element(screen.getByTestId('team-panel-team-2'))
       .not.toHaveClass(teamPanelStyles.serving!);
@@ -563,6 +564,7 @@ describe('ActiveMatchScreen', () => {
     await expect
       .element(screen.getByTestId('team-panel-team-2'))
       .not.toHaveClass(teamPanelStyles.serving!);
+    expect(screen.container.textContent).not.toContain('Serving: Player 1');
   });
 
   test('uses the countdown timer aria-label when countdown mode is enabled', async () => {

--- a/test/components/ActiveMatchScreen/TeamPanel.browser.test.tsx
+++ b/test/components/ActiveMatchScreen/TeamPanel.browser.test.tsx
@@ -85,7 +85,12 @@ describe('TeamPanel', () => {
 
   test('applies serving styles when the serving indicator is enabled', async () => {
     const screen = await render(
-      <TeamPanel {...createDefaultProps()} isServing={true} showServingIndicator={true} />
+      <TeamPanel
+        {...createDefaultProps()}
+        isServing={true}
+        servingPlayerNumber={1}
+        showServingIndicator={true}
+      />
     );
 
     const panel = screen.getByRole('button');
@@ -98,6 +103,19 @@ describe('TeamPanel', () => {
     expect(getComputedStyle(score.element()).color).toBe(
       resolveCssColor('color', 'var(--semantic-color-items-primary-content)')
     );
+  });
+
+  test('appends the serving player label to the serving team name', async () => {
+    const screen = await render(
+      <TeamPanel
+        {...createDefaultProps()}
+        isServing={true}
+        servingPlayerNumber={2}
+        showServingIndicator={true}
+      />
+    );
+
+    await expect.element(screen.getByText('Team Alpha · Serving: Player 2')).toBeInTheDocument();
   });
 
   test('does not render games, serving, or golden point affordances', async () => {

--- a/test/core/match/serve-derived-state.test.ts
+++ b/test/core/match/serve-derived-state.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from 'vitest';
 
 import { continueMatch, projectMatch } from '@/core/match/replay';
-import { getActiveSet, getNextSetFirstServer, getServingTeam } from '@/core/match/derived-state';
+import {
+  getActiveSet,
+  getNextSetFirstServer,
+  getServingPlayerNumber,
+  getServingTeam
+} from '@/core/match/derived-state';
 
 import {
   createTestSetup,
@@ -18,7 +23,22 @@ describe('serve rotation and derived state', () => {
     const projection = projectMatch(setup, winQuickGame('team-1'));
 
     expect(projection.derived.servingTeam).toBe('team-2');
+    expect(projection.derived.servingPlayerNumber).toBe(1);
     expect(getActiveSet(projection.state)?.firstServer).toBe('team-1');
+  });
+
+  test('alternates each team serving player across standard service turns', () => {
+    const setup = createTestSetup();
+    const atStart = projectMatch(setup, []);
+    const afterOneGame = projectMatch(setup, winQuickGame('team-1'));
+    const afterTwoGames = projectMatch(setup, [
+      ...winQuickGame('team-1'),
+      ...winQuickGame('team-2')
+    ]);
+
+    expect(atStart.derived.servingPlayerNumber).toBe(1);
+    expect(afterOneGame.derived.servingPlayerNumber).toBe(1);
+    expect(afterTwoGames.derived.servingPlayerNumber).toBe(2);
   });
 
   test('follows deterministic tiebreak serving math', () => {
@@ -35,8 +55,11 @@ describe('serve rotation and derived state', () => {
     ]);
 
     expect(atTiebreakStart.derived.servingTeam).toBe('team-1');
+    expect(atTiebreakStart.derived.servingPlayerNumber).toBe(1);
     expect(afterOnePoint.derived.servingTeam).toBe('team-2');
+    expect(afterOnePoint.derived.servingPlayerNumber).toBe(1);
     expect(afterThreePoints.derived.servingTeam).toBe('team-1');
+    expect(afterThreePoints.derived.servingPlayerNumber).toBe(2);
   });
 
   test('carries next-set first server continuity through a tiebreak set', () => {
@@ -52,9 +75,28 @@ describe('serve rotation and derived state', () => {
     expect(projection.derived.activeSetIndex).toBe(2);
     expect(getActiveSet(projection.state)?.firstServer).toBe('team-2');
     expect(projection.derived.servingTeam).toBe('team-2');
+    expect(projection.derived.servingPlayerNumber).toBe(2);
     expect(
       completedSet && completedSet.completed ? getNextSetFirstServer(completedSet) : null
     ).toBe('team-2');
+  });
+
+  test('keeps serving-player rotation through a super tiebreak', () => {
+    const setup = createTestSetup({
+      format: 'best-of-1',
+      decidingSetSuperTiebreak: true,
+      bestOfOneDecidingBehavior: 'super-tiebreak'
+    });
+    const atStart = projectMatch(setup, []);
+    const afterOnePoint = projectMatch(setup, scorePoints('team-1'));
+    const afterThreePoints = projectMatch(setup, scorePoints('team-1', 'team-2', 'team-2'));
+
+    expect(atStart.derived.servingTeam).toBe('team-1');
+    expect(atStart.derived.servingPlayerNumber).toBe(1);
+    expect(afterOnePoint.derived.servingTeam).toBe('team-2');
+    expect(afterOnePoint.derived.servingPlayerNumber).toBe(1);
+    expect(afterThreePoints.derived.servingTeam).toBe('team-1');
+    expect(afterThreePoints.derived.servingPlayerNumber).toBe(2);
   });
 
   test('derives side-switch prompts from odd games within a set and every six tiebreak points', () => {
@@ -108,7 +150,9 @@ describe('serve rotation and derived state', () => {
     const projection = projectMatch(setup, winQuickSet('team-1'));
 
     expect(getServingTeam(projection.state)).toBeNull();
+    expect(getServingPlayerNumber(projection.state)).toBeNull();
     expect(projection.derived.servingTeam).toBeNull();
+    expect(projection.derived.servingPlayerNumber).toBeNull();
     expect(projection.derived.sideSwitch).toEqual({
       shouldPrompt: false,
       reason: null


### PR DESCRIPTION
## Summary

Adds a serving player number indicator (Player 1 / Player 2) to the active match screen, so players can see at a glance which specific player is serving on the serving team.

## What was added

### Core logic — `src/core/match/derived-state.ts`
- New `deriveServingPlayerNumber()` function that determines which player on the serving team is currently serving, based on the total points played and serving order rules.
- Integrated into existing derived-state pipeline.

### Types — `src/core/match/types.ts`
- Added `MatchServingPlayerNumber` type (`1 | 2`).

### UI — `src/components/ActiveMatchScreen/TeamPanel/TeamPanel.tsx`
- `TeamPanel` accepts new optional `servingPlayerNumber` prop.
- When provided, team name displays as `"Team Name · Serving: Player N"` with the interpolated i18n string.
- Screen-reader-only label also updated to use the player-specific serving text.

### Screen — `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx`
- Wires the derived `servingPlayerNumber` into each `TeamPanel`.

### i18n — `en.ts`, `es.ts`, `pt.ts`
- New translation key `match.servingPlayer`: `"Serving: Player {{number}}"` / `"Saque: Jugador {{number}}"` / `"Saque: Jogador {{number}}"`.

## Test coverage

- **Unit tests** (`test/core/match/serve-derived-state.test.ts`): 46 new assertions covering all serving-player derivation scenarios.
- **Browser tests** (`test/components/ActiveMatchScreen/TeamPanel.browser.test.tsx`): New test verifying the serving player label is appended to the team name.
- **Browser tests** (`test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx`): Asserts serving player label appears in the active match screen and is absent when indicator is disabled.

## QA results

- ✅ 102 test suites passed
- ✅ 1 117 tests passed
- ✅ Coverage: 89.06% statements | 80.87% branches | 88.93% functions | 89.49% lines
- ✅ Lint (oxlint) clean
- ✅ Format (oxfmt) clean
- ✅ Pre-push hooks passed

## Files changed (10)

| File | Change |
|------|--------|
| `src/core/match/types.ts` | Added `MatchServingPlayerNumber` type |
| `src/core/match/derived-state.ts` | Added `deriveServingPlayerNumber()` + integration |
| `src/components/ActiveMatchScreen/TeamPanel/TeamPanel.tsx` | Serving player label in team name + SR label |
| `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx` | Wire serving player number to TeamPanel |
| `src/lib/i18n/locales/en.ts` | `servingPlayer` key |
| `src/lib/i18n/locales/es.ts` | `servingPlayer` key |
| `src/lib/i18n/locales/pt.ts` | `servingPlayer` key |
| `test/core/match/serve-derived-state.test.ts` | Unit tests for serving player derivation |
| `test/components/ActiveMatchScreen/TeamPanel.browser.test.tsx` | Browser test for label rendering |
| `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx` | Integration test for serving indicator |