### PR TITLE
feat: show full tiebreak points in set summaries

### DIFF
--- a/docs/development-logs/Task PBW-112 Tie-Break Winner Points in Set Summaries.md
+++ b/docs/development-logs/Task PBW-112 Tie-Break Winner Points in Set Summaries.md
@@ -1,0 +1,97 @@
+---
+title: PBW-112 Tie-Break Winner Points in Set Summaries
+type: development-log
+permalink: docs/development-logs/task-pbw-112-tie-break-winner-points-in-set-summaries
+---
+
+# Development Log: PBW-112
+
+## Metadata
+
+- Task ID: PBW-112
+- Date (UTC): 2026-05-25T12:00:00Z
+- Project: padelbuddy-web
+- Branch: feature/PBW-112-tie-break-winner-points-set-summaries
+- Commit: c4766e0 (branch not yet merged)
+
+## Objective
+
+- Show both tiebreak point totals (winner + loser) in completed standard tie-break sets with smaller typography where space permits. Surfaces: match end summary, history games column, active match sets history modal, shared result image/card.
+
+## Implementation Summary
+
+- Added/refined shared model `src/core/match/set-summary.ts` for structured set score data.
+- Created reusable presentational atom `src/components/SetScoreValue/SetScoreValue.tsx` rendering tiebreak detail conditionally.
+- Updated four consumer surfaces to consume the shared model and atom:
+  - **Match end summary** (`MatchSummaryCard`) — tiebreak sets show full point totals with smaller font.
+  - **History screen games column** (`HistoryScreen`) — same treatment in history table.
+  - **Active match sets history modal** (`SetsHistoryModal`) — same treatment in modal view.
+  - **Share screen / card** (`ShareScreen`, `match-share.ts`) — same treatment in shareable image.
+- Applied maintainability fixes:
+  - Removed string round-trip parsing — scores now flow as structured data, not serialized/parsed strings.
+  - Unified history visible/share score derivation into single shared path.
+  - Reused `SetScoreValue` atom across all surfaces instead of per-surface inline rendering.
+- Behavior preserved for: super tiebreak sets, non-tiebreak sets, in-progress sets.
+
+## Files Changed
+
+### Shared Model & Presentational Atom
+
+- `src/core/match/set-summary.ts` — structured set score model with tiebreak point data
+- `src/components/SetScoreValue/SetScoreValue.tsx` — reusable atom rendering set score with optional tiebreak detail
+
+### Match End Summary
+
+- `src/components/MatchEndScreen/MatchSummaryCard.tsx` — consume shared model + atom
+- `src/components/MatchEndScreen/MatchSummaryCard.module.css` — smaller typography for tiebreak points
+- `src/components/MatchEndScreen/view-model.ts` — derive structured set summaries from match state
+
+### History Screen
+
+- `src/components/HistoryScreen/HistoryScreen.tsx` — consume shared model + atom
+- `src/components/HistoryScreen/HistoryScreen.module.css` — styling for tiebreak detail in games column
+
+### Active Match Sets History Modal
+
+- `src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx` — consume shared model + atom
+- `src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.module.css` — styling adjustments
+
+### Share Screen / Card
+
+- `src/components/ShareScreen/ShareScreen.tsx` — consume shared model + atom
+- `src/components/ShareScreen/ShareScreen.module.css` — styling for tiebreak detail in share image
+- `src/lib/share/match-share.ts` — unified share score derivation using shared model
+
+### Tests
+
+- `test/components/MatchEndScreen/view-model.test.ts` — unit tests for set-summary view model
+- `test/components/MatchEndScreen/MatchEndScreen.browser.test.tsx` — browser tests for match end display
+- `test/components/HistoryScreen/HistoryScreen.browser.test.tsx` — browser tests for history display
+- `test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx` — browser tests for modal display
+- `test/components/ShareScreen/ShareScreen.browser.test.tsx` — browser tests for share card display
+
+### E2E
+
+- `e2e/history.happy-path.spec.ts` — updated happy-path with tiebreak score expectations
+- `e2e/tiebreaks.edge-case.spec.ts` — updated edge-case specs for tiebreak detail rendering
+
+## Key Decisions
+
+- **Shared `set-summary.ts` model over per-surface parsing**: Eliminates string round-trip parsing; single source of truth for set score structure. Reduces drift risk across surfaces.
+- **Reusable `SetScoreValue` atom**: Centralizes tiebreak rendering logic. Any new surface displaying set scores reuses this component. Avoids four duplicate implementations.
+- **Smaller typography only where space permits**: Tiebreak point totals rendered with reduced font size to avoid layout overflow. Constraint-driven decision per surface.
+- **Super tiebreak / non-tiebreak / in-progress unchanged**: Explicit no-op guard ensures existing behavior preserved. Reduces regression risk.
+
+## Validation Performed
+
+- `pnpm complete-check` — full suite passes (lint, format, type-check, unit tests, browser tests, e2e).
+- Manual verification across all four surfaces: match end, history, modal, share card.
+- Confirmed super tiebreak sets render unchanged (no tiebreak detail shown).
+- Confirmed non-tiebreak sets render unchanged.
+- Confirmed in-progress sets render unchanged.
+
+## Risks and Follow-ups
+
+- **Share card image width**: Tiebreak detail in share card uses smaller font; extremely long scores (e.g., 20-18) may still overflow on narrow share images. Monitor and potentially truncate or scale dynamically.
+- **E2E visual regression**: No automated visual regression tests yet. Consider adding screenshot comparison for tiebreak score rendering across surfaces.
+- **Future surfaces**: Any new surface needing set scores should import `SetScoreValue` directly — document this convention in component README or architecture notes.

--- a/e2e/history.happy-path.spec.ts
+++ b/e2e/history.happy-path.spec.ts
@@ -18,7 +18,9 @@ test.describe('@happy-path @history History screen', () => {
     await expect(page.getByText('Beta')).toBeVisible();
     await expect(page.getByRole('table')).toBeVisible();
     await expect(page.getByText('1-0')).toBeVisible();
-    await expect(page.getByText('6-0')).toBeVisible();
+
+    const gamesCell = page.getByTestId('history-games-history-render-test');
+    await expect(gamesCell).toContainText(/6\s*-\s*0/);
   });
 
   test('share button is visible and clickable', async ({ page }) => {

--- a/e2e/tiebreaks.edge-case.spec.ts
+++ b/e2e/tiebreaks.edge-case.spec.ts
@@ -41,7 +41,10 @@ test.describe('@edge-case @active-match @match-end Tiebreak flows', () => {
     await team1Panel.click();
 
     await expect(page).toHaveURL(/\/match\/finish\/[^/]+$/);
-    await expect(page.getByTestId('match-end-set-row-1')).toContainText('7-6');
+    const firstSetRow = page.getByTestId('match-end-set-row-1');
+
+    await expect(firstSetRow).toContainText(/Set 1:\s*Team A 7\s*\(7\),\s*Team B 6\s*\(5\)/i);
+    await expect(firstSetRow).toContainText(/7\s*\(7\)\s*-\s*6\s*\(5\)/);
   });
 
   test('uses default deciding-set super tiebreak target (11) in best-of-3', async ({ page }) => {

--- a/src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.module.css
+++ b/src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.module.css
@@ -5,7 +5,7 @@
 .container {
   pointer-events: auto;
   composes: modalcontainer from '../../../styles/shared-setup-modal.module.css';
-  width: min(calc(100vw - (var(--base-space-16) * 2)), calc(var(--base-space-40) * 13));
+  width: min(calc(100vw - (var(--base-space-16) * 2)), calc(var(--base-space-40) * 14));
   max-height: calc(100dvh - (var(--base-space-16) * 2));
   gap: var(--base-space-16);
 }

--- a/src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.module.css
+++ b/src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.module.css
@@ -84,6 +84,14 @@
   color: var(--semantic-color-content-primary);
 }
 
+.tiebreakPoints {
+  margin-left: var(--base-space-2);
+  margin-right: var(--base-space-2);
+  font-family: var(--semantic-typography-family-body);
+  font-size: var(--base-font-size-13);
+  font-weight: var(--semantic-typography-weight-strong);
+}
+
 .emptyState {
   margin: 0;
   padding: var(--base-space-10) var(--base-space-12);

--- a/src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx
+++ b/src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx
@@ -9,9 +9,11 @@ import {
 import { Dialog } from '@base-ui/react/dialog';
 import { useTranslation } from 'react-i18next';
 
+import { SetScoreValue } from '@/components/SetScoreValue/SetScoreValue';
+import { getSetSummaryScoreParts } from '@/core/match/set-summary';
 import type { MatchSetState } from '@/core/match/types';
 
-import { getSetDisplayScore, getSetsWonScore } from '../sets-history';
+import { getSetsWonScore } from '../sets-history';
 
 import styles from './SetsHistoryModal.module.css';
 
@@ -68,7 +70,7 @@ export function SetsHistoryModal({
       sets
         .filter((set) => set.completed)
         .map((set) => {
-          const setScore = getSetDisplayScore(set);
+          const setScore = getSetSummaryScoreParts(set);
 
           return {
             setNumber: set.index,
@@ -107,7 +109,11 @@ export function SetsHistoryModal({
                 <span className={styles.setLabel}>
                   {t('match.sets.setLabel', { number: row.setNumber })}
                 </span>
-                <span className={styles.score}>{`${row.team1} - ${row.team2}`}</span>
+                <span className={styles.score}>
+                  <SetScoreValue score={row.team1} tiebreakClassName={styles.tiebreakPoints} />
+                  <span> - </span>
+                  <SetScoreValue score={row.team2} tiebreakClassName={styles.tiebreakPoints} />
+                </span>
               </li>
             ))}
           </ul>

--- a/src/components/HistoryScreen/HistoryScreen.module.css
+++ b/src/components/HistoryScreen/HistoryScreen.module.css
@@ -154,6 +154,23 @@
   color: var(--semantic-color-content-primary);
 }
 
+.gamesSetScore {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--base-space-2);
+}
+
+.tiebreakPoints {
+  font-family: var(--semantic-typography-family-body);
+  font-size: var(--base-font-size-11);
+  font-weight: var(--semantic-typography-weight-strong);
+}
+
+.setScoreSeparator,
+.setScoreListSeparator {
+  white-space: pre;
+}
+
 .actionsCell {
   display: flex;
   flex-direction: column;

--- a/src/components/HistoryScreen/HistoryScreen.tsx
+++ b/src/components/HistoryScreen/HistoryScreen.tsx
@@ -3,8 +3,10 @@ import { useNavigate } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 
 import { ShareScreen, type ShareScreenProps } from '@/components/ShareScreen/ShareScreen';
+import { SetScoreValue } from '@/components/SetScoreValue/SetScoreValue';
 import { getMatchTeamName } from '@/core/match/team-name';
 import { projectMatch } from '@/core/match/replay';
+import { formatSetSummaryScorePart, getSetSummaryScoreParts } from '@/core/match/set-summary';
 import type { MatchFormat, MatchSetState, MatchTeamId } from '@/core/match/types';
 import { deleteMatchHistory } from '@/lib/match-history/indexed-db';
 import { saveSetupPreferenceSlice } from '@/lib/setup/setup-storage';
@@ -30,6 +32,7 @@ interface HistoryRow {
   setsScore: string;
   setsScoreUnfinished: boolean;
   gamesScore: string;
+  setScoreRows: ShareScreenProps['setRows'];
   dateLabel: string;
   winnerTeamId: MatchTeamId | null;
   finishedAt: number;
@@ -69,6 +72,15 @@ export function HistoryScreen({ initialRecords }: HistoryScreenProps) {
         const requiredSetsToWin = requiredSetsToWinByFormat[record.setup.format];
         const winner = determineWinnerFromCompletedSets(projection.state.sets);
         const isFinishedEarly = completedSetsCount < requiredSetsToWin || !winner;
+        const setScoreRows: ShareScreenProps['setRows'] = projection.state.sets.map((set) => {
+          const scoreParts = getSetSummaryScoreParts(set);
+
+          return {
+            setNumber: set.index,
+            team1Games: scoreParts['team-1'],
+            team2Games: scoreParts['team-2']
+          };
+        });
 
         return {
           id: record.matchId,
@@ -76,7 +88,8 @@ export function HistoryScreen({ initialRecords }: HistoryScreenProps) {
           team2Name: getMatchTeamName(record.setup, 'team-2'),
           setsScore: toSetsScore(projection.state.sets),
           setsScoreUnfinished: isFinishedEarly,
-          gamesScore: toGamesScore(projection.state.sets),
+          gamesScore: toGamesScore(setScoreRows),
+          setScoreRows,
           dateLabel: formatHistoryDate(record.finishedAt, i18n.language),
           winnerTeamId: winner?.teamId ?? null,
           finishedAt: record.finishedAt,
@@ -99,14 +112,13 @@ export function HistoryScreen({ initialRecords }: HistoryScreenProps) {
     }
 
     const { record } = sharingRecord;
-    const projection = projectMatch(record.setup, record.actions);
-    const winner = determineWinnerFromCompletedSets(projection.state.sets);
     const isFinishedEarly = sharingRecord.setsScoreUnfinished;
+    const winnerTeamId = sharingRecord.winnerTeamId;
 
     const winnerNameValue = isFinishedEarly
       ? t('match.end.winner.finishedEarlyName')
-      : winner
-        ? winner.teamId === 'team-1'
+      : winnerTeamId
+        ? winnerTeamId === 'team-1'
           ? sharingRecord.team1Name
           : sharingRecord.team2Name
         : '';
@@ -131,23 +143,13 @@ export function HistoryScreen({ initialRecords }: HistoryScreenProps) {
       year: '2-digit'
     }).format(new Date(record.finishedAt));
 
-    const setRows = projection.state.sets.map((set) => {
-      const setScore = getSetScoreForHistory(set);
-
-      return {
-        setNumber: set.index,
-        team1Games: setScore['team-1'],
-        team2Games: setScore['team-2']
-      };
-    });
-
     return {
       winnerName: winnerNameValue,
       ...(sharingRecord.winnerTeamId ? { winnerTeamId: sharingRecord.winnerTeamId } : {}),
       team1Name: sharingRecord.team1Name,
       team2Name: sharingRecord.team2Name,
       formatLabel,
-      setRows,
+      setRows: sharingRecord.setScoreRows,
       durationValue,
       dateValue
     };
@@ -421,7 +423,24 @@ export function HistoryScreen({ initialRecords }: HistoryScreenProps) {
                         row.setsScore
                       )}
                     </td>
-                    <td className={styles.gamesCell}>{row.gamesScore}</td>
+                    <td className={styles.gamesCell} data-testid={`history-games-${row.id}`}>
+                      {row.setScoreRows.map((setRow, index) => (
+                        <span key={setRow.setNumber} className={styles.gamesSetScore}>
+                          <SetScoreValue
+                            score={setRow.team1Games}
+                            tiebreakClassName={styles.tiebreakPoints}
+                          />
+                          <span className={styles.setScoreSeparator}> - </span>
+                          <SetScoreValue
+                            score={setRow.team2Games}
+                            tiebreakClassName={styles.tiebreakPoints}
+                          />
+                          {index < row.setScoreRows.length - 1 && (
+                            <span className={styles.setScoreListSeparator}>, </span>
+                          )}
+                        </span>
+                      ))}
+                    </td>
                     <td className={styles.actionsCell}>
                       <div className={styles.iconActionsRow}>
                         <button
@@ -529,25 +548,12 @@ function toSetsScore(sets: MatchSetState[]): string {
   return `${teamOneSetsWon}-${teamTwoSetsWon}`;
 }
 
-function getSetScoreForHistory(set: MatchSetState): {
-  'team-1': number;
-  'team-2': number;
-} {
-  const superTiebreakPoints =
-    set.completed && set.mode === 'super-tiebreak' ? set.tiebreakPoints : null;
-
-  return {
-    'team-1': superTiebreakPoints?.['team-1'] ?? set.games['team-1'],
-    'team-2': superTiebreakPoints?.['team-2'] ?? set.games['team-2']
-  };
-}
-
-function toGamesScore(sets: MatchSetState[]): string {
-  return sets
-    .map((set) => {
-      const setScore = getSetScoreForHistory(set);
-      return `${setScore['team-1']}-${setScore['team-2']}`;
-    })
+function toGamesScore(setScoreRows: ShareScreenProps['setRows']): string {
+  return setScoreRows
+    .map(
+      (row) =>
+        `${formatSetSummaryScorePart(row.team1Games)}-${formatSetSummaryScorePart(row.team2Games)}`
+    )
     .join(', ');
 }
 

--- a/src/components/HistoryScreen/HistoryScreen.tsx
+++ b/src/components/HistoryScreen/HistoryScreen.tsx
@@ -81,8 +81,8 @@ export function HistoryScreen({ initialRecords }: HistoryScreenProps) {
 
           return {
             setNumber: set.index,
-            team1Games: scoreParts['team-1'],
-            team2Games: scoreParts['team-2']
+            team1Score: scoreParts['team-1'],
+            team2Score: scoreParts['team-2']
           };
         });
 
@@ -201,8 +201,8 @@ export function HistoryScreen({ initialRecords }: HistoryScreenProps) {
             ? shareScreenProps.setRows.map((row) => ({
                 setNumber: row.setNumber,
                 scores: {
-                  'team-1': row.team1Games,
-                  'team-2': row.team2Games
+                  'team-1': row.team1Score,
+                  'team-2': row.team2Score
                 },
                 isSuperTiebreak: false
               }))
@@ -431,12 +431,12 @@ export function HistoryScreen({ initialRecords }: HistoryScreenProps) {
                       {row.setScoreRows.map((setRow, index) => (
                         <span key={setRow.setNumber} className={styles.gamesSetScore}>
                           <SetScoreValue
-                            score={setRow.team1Games}
+                            score={setRow.team1Score}
                             tiebreakClassName={styles.tiebreakPoints}
                           />
                           <span className={styles.setScoreSeparator}> - </span>
                           <SetScoreValue
-                            score={setRow.team2Games}
+                            score={setRow.team2Score}
                             tiebreakClassName={styles.tiebreakPoints}
                           />
                           {index < row.setScoreRows.length - 1 && (
@@ -556,7 +556,7 @@ function toGamesScore(setScoreRows: SetSummaryRow[]): string {
   return setScoreRows
     .map(
       (row) =>
-        `${formatSetSummaryScorePart(row.team1Games)}-${formatSetSummaryScorePart(row.team2Games)}`
+        `${formatSetSummaryScorePart(row.team1Score)}-${formatSetSummaryScorePart(row.team2Score)}`
     )
     .join(', ');
 }

--- a/src/components/HistoryScreen/HistoryScreen.tsx
+++ b/src/components/HistoryScreen/HistoryScreen.tsx
@@ -6,7 +6,11 @@ import { ShareScreen, type ShareScreenProps } from '@/components/ShareScreen/Sha
 import { SetScoreValue } from '@/components/SetScoreValue/SetScoreValue';
 import { getMatchTeamName } from '@/core/match/team-name';
 import { projectMatch } from '@/core/match/replay';
-import { formatSetSummaryScorePart, getSetSummaryScoreParts } from '@/core/match/set-summary';
+import {
+  formatSetSummaryScorePart,
+  getSetSummaryScoreParts,
+  type SetSummaryRow
+} from '@/core/match/set-summary';
 import type { MatchFormat, MatchSetState, MatchTeamId } from '@/core/match/types';
 import { deleteMatchHistory } from '@/lib/match-history/indexed-db';
 import { saveSetupPreferenceSlice } from '@/lib/setup/setup-storage';
@@ -32,7 +36,7 @@ interface HistoryRow {
   setsScore: string;
   setsScoreUnfinished: boolean;
   gamesScore: string;
-  setScoreRows: ShareScreenProps['setRows'];
+  setScoreRows: SetSummaryRow[];
   dateLabel: string;
   winnerTeamId: MatchTeamId | null;
   finishedAt: number;
@@ -72,7 +76,7 @@ export function HistoryScreen({ initialRecords }: HistoryScreenProps) {
         const requiredSetsToWin = requiredSetsToWinByFormat[record.setup.format];
         const winner = determineWinnerFromCompletedSets(projection.state.sets);
         const isFinishedEarly = completedSetsCount < requiredSetsToWin || !winner;
-        const setScoreRows: ShareScreenProps['setRows'] = projection.state.sets.map((set) => {
+        const setScoreRows: SetSummaryRow[] = projection.state.sets.map((set) => {
           const scoreParts = getSetSummaryScoreParts(set);
 
           return {
@@ -548,7 +552,7 @@ function toSetsScore(sets: MatchSetState[]): string {
   return `${teamOneSetsWon}-${teamTwoSetsWon}`;
 }
 
-function toGamesScore(setScoreRows: ShareScreenProps['setRows']): string {
+function toGamesScore(setScoreRows: SetSummaryRow[]): string {
   return setScoreRows
     .map(
       (row) =>

--- a/src/components/MatchEndScreen/MatchEndScreen.tsx
+++ b/src/components/MatchEndScreen/MatchEndScreen.tsx
@@ -115,8 +115,8 @@ export function MatchEndScreen({
       formatLabel,
       setRows: summary.setRows.map((row) => ({
         setNumber: row.setNumber,
-        team1Games: row.scores['team-1'],
-        team2Games: row.scores['team-2']
+        team1Score: row.scores['team-1'],
+        team2Score: row.scores['team-2']
       })),
       durationValue,
       dateValue

--- a/src/components/MatchEndScreen/MatchSummaryCard.module.css
+++ b/src/components/MatchEndScreen/MatchSummaryCard.module.css
@@ -126,6 +126,13 @@
   line-height: 1;
 }
 
+.tiebreakPoints {
+  margin-left: var(--base-space-4);
+  font-family: var(--semantic-typography-family-body);
+  font-size: var(--base-font-size-18);
+  font-weight: var(--semantic-typography-weight-strong);
+}
+
 .setSeparator {
   min-width: 1.5rem;
   text-align: center;

--- a/src/components/MatchEndScreen/MatchSummaryCard.tsx
+++ b/src/components/MatchEndScreen/MatchSummaryCard.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from 'react-i18next';
 
 import { Card } from '@/components/ui/Card/Card';
+import { SetScoreValue } from '@/components/SetScoreValue/SetScoreValue';
+import { formatSetSummaryScorePart } from '@/core/match/set-summary';
 import type { TeamScore } from '@/core/match/types';
 import { cn } from '@/lib/utils/cn';
 
@@ -42,9 +44,9 @@ export function MatchSummaryCard({ formatLabel, teamNames, setRows }: MatchSumma
                 {t('match.end.summary.setScoreRow', {
                   setNumber: setRow.setNumber,
                   teamOneName: teamNames['team-1'],
-                  teamOneScore: setRow.scores['team-1'],
+                  teamOneScore: formatSetSummaryScorePart(setRow.scores['team-1']),
                   teamTwoName: teamNames['team-2'],
-                  teamTwoScore: setRow.scores['team-2']
+                  teamTwoScore: formatSetSummaryScorePart(setRow.scores['team-2'])
                 })}
               </span>
               <span
@@ -62,13 +64,19 @@ export function MatchSummaryCard({ formatLabel, teamNames, setRows }: MatchSumma
                 )}
               </span>
               <span aria-hidden="true" className={cn(styles.setScore, styles.teamPrimary)}>
-                {setRow.scores['team-1']}
+                <SetScoreValue
+                  score={setRow.scores['team-1']}
+                  tiebreakClassName={styles.tiebreakPoints}
+                />
               </span>
               <span aria-hidden="true" className={styles.setSeparator}>
                 -
               </span>
               <span aria-hidden="true" className={cn(styles.setScore, styles.teamSecondary)}>
-                {setRow.scores['team-2']}
+                <SetScoreValue
+                  score={setRow.scores['team-2']}
+                  tiebreakClassName={styles.tiebreakPoints}
+                />
               </span>
             </li>
           ))}

--- a/src/components/MatchEndScreen/view-model.ts
+++ b/src/components/MatchEndScreen/view-model.ts
@@ -1,10 +1,11 @@
 import { getMatchTeamName } from '@/core/match/team-name';
+import { getSetSummaryScoreParts, type SetSummaryScorePart } from '@/core/match/set-summary';
 import type { MatchFormat, MatchProjection, MatchTeamId, TeamScore } from '@/core/match/types';
 import { determineWinnerFromCompletedSets, getMatchDurationParts } from '@/lib/share/match-share';
 
 export interface MatchEndScreenSetRow {
   setNumber: number;
-  scores: TeamScore<number>;
+  scores: TeamScore<SetSummaryScorePart>;
   isSuperTiebreak: boolean;
 }
 
@@ -50,17 +51,10 @@ export function createMatchEndScreenSummary(
     format: projection.setup.format,
     setRows: projection.state.sets.map((set) => {
       const isSuperTiebreak = set.completed && set.mode === 'super-tiebreak';
-      const tiebreakPoints = isSuperTiebreak ? set.tiebreakPoints : null;
 
       return {
         setNumber: set.index,
-        scores:
-          tiebreakPoints !== null
-            ? tiebreakPoints
-            : {
-                'team-1': set.games['team-1'],
-                'team-2': set.games['team-2']
-              },
+        scores: getSetSummaryScoreParts(set),
         isSuperTiebreak
       };
     }),

--- a/src/components/SetScoreValue/SetScoreValue.tsx
+++ b/src/components/SetScoreValue/SetScoreValue.tsx
@@ -8,7 +8,7 @@ interface SetScoreValueProps {
 export function SetScoreValue({ score, tiebreakClassName }: SetScoreValueProps) {
   return (
     <>
-      <span>{score.games}</span>
+      <span>{score.score}</span>
       {score.tiebreakPoints !== undefined && (
         <span className={tiebreakClassName}>({score.tiebreakPoints})</span>
       )}

--- a/src/components/SetScoreValue/SetScoreValue.tsx
+++ b/src/components/SetScoreValue/SetScoreValue.tsx
@@ -1,0 +1,17 @@
+import type { SetSummaryScorePart } from '@/core/match/set-summary';
+
+interface SetScoreValueProps {
+  score: SetSummaryScorePart;
+  tiebreakClassName?: string | undefined;
+}
+
+export function SetScoreValue({ score, tiebreakClassName }: SetScoreValueProps) {
+  return (
+    <>
+      <span>{score.games}</span>
+      {score.tiebreakPoints !== undefined && (
+        <span className={tiebreakClassName}>({score.tiebreakPoints})</span>
+      )}
+    </>
+  );
+}

--- a/src/components/ShareScreen/ShareScreen.module.css
+++ b/src/components/ShareScreen/ShareScreen.module.css
@@ -181,6 +181,13 @@
   font-weight: var(--semantic-typography-weight-heading);
 }
 
+.tiebreakPoints {
+  margin-left: var(--base-space-4);
+  font-family: var(--semantic-typography-family-body);
+  font-size: var(--base-font-size-18);
+  font-weight: var(--semantic-typography-weight-strong);
+}
+
 .setDash {
   color: var(--semantic-color-content-secondary);
   font-family: var(--semantic-typography-family-display);

--- a/src/components/ShareScreen/ShareScreen.tsx
+++ b/src/components/ShareScreen/ShareScreen.tsx
@@ -91,11 +91,11 @@ export function ShareScreen({
                   {t('share.score.set', { number: row.setNumber })}
                 </span>
                 <span className={styles.winnerScore}>
-                  <SetScoreValue score={row.team1Games} tiebreakClassName={styles.tiebreakPoints} />
+                  <SetScoreValue score={row.team1Score} tiebreakClassName={styles.tiebreakPoints} />
                 </span>
                 <span className={styles.setDash}>-</span>
                 <span className={styles.loserScore}>
-                  <SetScoreValue score={row.team2Games} tiebreakClassName={styles.tiebreakPoints} />
+                  <SetScoreValue score={row.team2Score} tiebreakClassName={styles.tiebreakPoints} />
                 </span>
               </div>
             ))}

--- a/src/components/ShareScreen/ShareScreen.tsx
+++ b/src/components/ShareScreen/ShareScreen.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
-import type { SetSummaryScorePart } from '@/core/match/set-summary';
+import type { SetSummaryRow } from '@/core/match/set-summary';
 import type { MatchTeamId } from '@/core/match/types';
 import { SetScoreValue } from '@/components/SetScoreValue/SetScoreValue';
 import { TrophyIcon } from '@/components/ui/Icon/TrophyIcon';
@@ -16,11 +16,7 @@ export interface ShareScreenProps {
   team1Name: string;
   team2Name: string;
   formatLabel: string;
-  setRows: Array<{
-    setNumber: number;
-    team1Games: SetSummaryScorePart;
-    team2Games: SetSummaryScorePart;
-  }>;
+  setRows: SetSummaryRow[];
   durationValue: string;
   dateValue: string;
 }

--- a/src/components/ShareScreen/ShareScreen.tsx
+++ b/src/components/ShareScreen/ShareScreen.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from 'react-i18next';
 
+import type { SetSummaryScorePart } from '@/core/match/set-summary';
 import type { MatchTeamId } from '@/core/match/types';
+import { SetScoreValue } from '@/components/SetScoreValue/SetScoreValue';
 import { TrophyIcon } from '@/components/ui/Icon/TrophyIcon';
 import { TopBar } from '@/components/ui/TopBar/TopBar';
 
@@ -16,8 +18,8 @@ export interface ShareScreenProps {
   formatLabel: string;
   setRows: Array<{
     setNumber: number;
-    team1Games: number;
-    team2Games: number;
+    team1Games: SetSummaryScorePart;
+    team2Games: SetSummaryScorePart;
   }>;
   durationValue: string;
   dateValue: string;
@@ -92,9 +94,13 @@ export function ShareScreen({
                 <span className={styles.setLabel}>
                   {t('share.score.set', { number: row.setNumber })}
                 </span>
-                <span className={styles.winnerScore}>{row.team1Games}</span>
+                <span className={styles.winnerScore}>
+                  <SetScoreValue score={row.team1Games} tiebreakClassName={styles.tiebreakPoints} />
+                </span>
                 <span className={styles.setDash}>-</span>
-                <span className={styles.loserScore}>{row.team2Games}</span>
+                <span className={styles.loserScore}>
+                  <SetScoreValue score={row.team2Games} tiebreakClassName={styles.tiebreakPoints} />
+                </span>
               </div>
             ))}
           </div>

--- a/src/core/match/set-summary.ts
+++ b/src/core/match/set-summary.ts
@@ -1,16 +1,22 @@
 import type { CompletedMatchSet, MatchSetState, TeamScore } from './types';
 
 export interface SetSummaryScorePart {
-  games: string;
+  score: string;
   tiebreakPoints?: string;
+}
+
+export interface SetSummaryRow {
+  setNumber: number;
+  team1Games: SetSummaryScorePart;
+  team2Games: SetSummaryScorePart;
 }
 
 export function formatSetSummaryScorePart(value: SetSummaryScorePart): string {
   if (value.tiebreakPoints !== undefined) {
-    return `${value.games} (${value.tiebreakPoints})`;
+    return `${value.score} (${value.tiebreakPoints})`;
   }
 
-  return value.games;
+  return value.score;
 }
 
 function toStringScore(scores: TeamScore<number>): TeamScore<string> {
@@ -59,18 +65,18 @@ export function getSetSummaryScoreParts(set: MatchSetState): TeamScore<SetSummar
 
   if (!isCompletedStandardTiebreakSetWithPoints(set)) {
     return {
-      'team-1': { games: baseScores['team-1'] },
-      'team-2': { games: baseScores['team-2'] }
+      'team-1': { score: baseScores['team-1'] },
+      'team-2': { score: baseScores['team-2'] }
     };
   }
 
   return {
     'team-1': {
-      games: `${set.games['team-1']}`,
+      score: `${set.games['team-1']}`,
       tiebreakPoints: `${set.tiebreakPoints['team-1']}`
     },
     'team-2': {
-      games: `${set.games['team-2']}`,
+      score: `${set.games['team-2']}`,
       tiebreakPoints: `${set.tiebreakPoints['team-2']}`
     }
   };

--- a/src/core/match/set-summary.ts
+++ b/src/core/match/set-summary.ts
@@ -1,0 +1,86 @@
+import type { CompletedMatchSet, MatchSetState, TeamScore } from './types';
+
+export interface SetSummaryScorePart {
+  games: string;
+  tiebreakPoints?: string;
+}
+
+export function formatSetSummaryScorePart(value: SetSummaryScorePart): string {
+  if (value.tiebreakPoints !== undefined) {
+    return `${value.games} (${value.tiebreakPoints})`;
+  }
+
+  return value.games;
+}
+
+function toStringScore(scores: TeamScore<number>): TeamScore<string> {
+  return {
+    'team-1': `${scores['team-1']}`,
+    'team-2': `${scores['team-2']}`
+  };
+}
+
+function getBaseSetSummaryScores(set: MatchSetState): TeamScore<number> {
+  if (set.completed && set.mode === 'super-tiebreak' && set.tiebreakPoints !== null) {
+    return set.tiebreakPoints;
+  }
+
+  return set.games;
+}
+
+function isCompletedStandardTiebreakSetWithPoints(
+  set: MatchSetState
+): set is CompletedMatchSet & { mode: 'standard'; tiebreakPoints: TeamScore<number> } {
+  if (!set.completed) {
+    return false;
+  }
+
+  if (set.mode !== 'standard' || set.tiebreakPoints === null) {
+    return false;
+  }
+
+  const team1Games = set.games['team-1'];
+  const team2Games = set.games['team-2'];
+
+  return (team1Games === 7 && team2Games === 6) || (team1Games === 6 && team2Games === 7);
+}
+
+export function getSetSummaryScores(set: MatchSetState): TeamScore<string> {
+  const scoreParts = getSetSummaryScoreParts(set);
+
+  return {
+    'team-1': formatSetSummaryScorePart(scoreParts['team-1']),
+    'team-2': formatSetSummaryScorePart(scoreParts['team-2'])
+  };
+}
+
+export function getSetSummaryScoreParts(set: MatchSetState): TeamScore<SetSummaryScorePart> {
+  const baseScores = toStringScore(getBaseSetSummaryScores(set));
+
+  if (!isCompletedStandardTiebreakSetWithPoints(set)) {
+    return {
+      'team-1': { games: baseScores['team-1'] },
+      'team-2': { games: baseScores['team-2'] }
+    };
+  }
+
+  return {
+    'team-1': {
+      games: `${set.games['team-1']}`,
+      tiebreakPoints: `${set.tiebreakPoints['team-1']}`
+    },
+    'team-2': {
+      games: `${set.games['team-2']}`,
+      tiebreakPoints: `${set.tiebreakPoints['team-2']}`
+    }
+  };
+}
+
+export function formatSetSummaryScore(
+  set: MatchSetState,
+  options: { separator?: string } = {}
+): string {
+  const { separator = ' - ' } = options;
+  const score = getSetSummaryScores(set);
+  return `${score['team-1']}${separator}${score['team-2']}`;
+}

--- a/src/core/match/set-summary.ts
+++ b/src/core/match/set-summary.ts
@@ -7,8 +7,8 @@ export interface SetSummaryScorePart {
 
 export interface SetSummaryRow {
   setNumber: number;
-  team1Games: SetSummaryScorePart;
-  team2Games: SetSummaryScorePart;
+  team1Score: SetSummaryScorePart;
+  team2Score: SetSummaryScorePart;
 }
 
 export function formatSetSummaryScorePart(value: SetSummaryScorePart): string {

--- a/src/lib/share/match-share.ts
+++ b/src/lib/share/match-share.ts
@@ -1,4 +1,5 @@
 import type { MatchSetState, MatchTeamId } from '@/core/match/types';
+import type { SetSummaryScorePart } from '@/core/match/set-summary';
 
 // ============================================================================
 // Shared types
@@ -22,7 +23,7 @@ interface ShareSummary {
   teamNames: { 'team-1': string; 'team-2': string };
   setRows: Array<{
     setNumber: number;
-    scores: { 'team-1': number; 'team-2': number };
+    scores: { 'team-1': SetSummaryScorePart; 'team-2': SetSummaryScorePart };
     isSuperTiebreak: boolean;
   }>;
   totalGames: number;

--- a/test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx
+++ b/test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx
@@ -138,4 +138,30 @@ describe('SetsHistoryModal', () => {
       .toHaveTextContent(en.match.sets.emptyHistory);
     await expect.element(screen.getByTestId('sets-history-modal-list')).not.toBeInTheDocument();
   });
+
+  test('renders completed standard tiebreak winner points in history rows', async () => {
+    const onClose = vi.fn<() => void>();
+    const screen = await render(
+      <SetsHistoryModal
+        isOpen
+        openToken={1}
+        sets={[
+          {
+            index: 1,
+            mode: 'standard',
+            firstServer: 'team-1',
+            completed: true,
+            winner: 'team-1',
+            games: { 'team-1': 7, 'team-2': 6 },
+            tiebreakPoints: { 'team-1': 8, 'team-2': 6 }
+          }
+        ]}
+        onClose={onClose}
+      />
+    );
+
+    await expect
+      .element(screen.getByTestId('sets-history-modal-list'))
+      .toHaveTextContent('7(8) - 6(6)');
+  });
 });

--- a/test/components/HistoryScreen/HistoryScreen.browser.test.tsx
+++ b/test/components/HistoryScreen/HistoryScreen.browser.test.tsx
@@ -5,7 +5,13 @@ import { HistoryScreen } from '@/components/HistoryScreen/HistoryScreen';
 import { ToastProvider, globalToastManager } from '@/components/ui/Toast/useToast';
 import { createMatchHistoryRecord } from '@/lib/match-history/persistence';
 
-import { createTestSetup, winQuickSet } from '../../core/match/test-helpers';
+import {
+  createTestSetup,
+  reachSixAll,
+  repeatAction,
+  scorePoints,
+  winQuickSet
+} from '../../core/match/test-helpers';
 
 const {
   mockNavigate,
@@ -167,6 +173,30 @@ describe('HistoryScreen', () => {
     await screen.getByRole('button', { name: /^back$/i }).click();
 
     expect(mockNavigate).toHaveBeenCalledWith({ to: '/' });
+  });
+
+  test('renders completed standard tiebreak winner points in games column', async () => {
+    const finishedAt = Date.now();
+    const record = createMatchHistoryRecord({
+      matchId: 'history-tiebreak',
+      setup: createTestSetup(),
+      actions: [
+        ...reachSixAll(),
+        ...repeatAction('team-1', 7),
+        ...repeatAction('team-2', 6),
+        ...scorePoints('team-1')
+      ],
+      startedAt: finishedAt - 120_000,
+      finishedAt
+    });
+
+    const screen = await render(<HistoryScreen initialRecords={[record]} />);
+
+    const gamesCell = screen.getByTestId('history-games-history-tiebreak');
+
+    await expect.element(gamesCell).toHaveTextContent(/7\s*\(7\)\s*-\s*6\s*\(0\)/);
+    await expect.element(gamesCell).toHaveTextContent('(7)');
+    await expect.element(gamesCell).toHaveTextContent('(0)');
   });
 });
 

--- a/test/components/MatchEndScreen/MatchEndScreen.browser.test.tsx
+++ b/test/components/MatchEndScreen/MatchEndScreen.browser.test.tsx
@@ -3,7 +3,13 @@ import { render } from 'vitest-browser-react';
 
 import { MatchEndScreen } from '@/components/MatchEndScreen/MatchEndScreen';
 import { projectMatch } from '@/core/match/replay';
-import { createTestSetup, winQuickSet } from '../../core/match/test-helpers';
+import {
+  createTestSetup,
+  reachSixAll,
+  repeatAction,
+  scorePoints,
+  winQuickSet
+} from '../../core/match/test-helpers';
 
 const currentTime = new Date('2026-03-19T13:24:00.000Z');
 const startedAt = currentTime.getTime() - 20 * 60 * 1000;
@@ -218,6 +224,30 @@ describe('MatchEndScreen', () => {
     await expect.element(screen.getByTestId('new-match-button')).toBeInTheDocument();
     await expect.element(screen.getByTestId('continue-match-button')).toBeInTheDocument();
     expect(screen.container.querySelector('[aria-haspopup="true"]')).toBeNull();
+  });
+
+  test('renders completed standard tiebreak winner points in set summary', async () => {
+    const setup = createCompletedSetup();
+    const actions = [
+      ...reachSixAll(),
+      ...repeatAction('team-1', 7),
+      ...repeatAction('team-2', 6),
+      ...scorePoints('team-1')
+    ];
+    const projection = projectMatch(setup, actions);
+
+    const screen = await render(
+      <MatchEndScreen
+        matchId="test-match-tiebreak"
+        setup={setup}
+        actions={actions}
+        projection={projection}
+        startedAt={startedAt}
+        finishedAt={finishedAt}
+      />
+    );
+
+    await expect.element(screen.getByTestId('match-end-set-row-1')).toHaveTextContent('7(7)-6(0)');
   });
 
   test('renders an enabled share action in the header', async () => {

--- a/test/components/MatchEndScreen/view-model.test.ts
+++ b/test/components/MatchEndScreen/view-model.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@/components/MatchEndScreen/view-model';
 import {
   createTestSetup,
+  reachSixAll,
   repeatAction,
   scorePoints,
   winQuickGame,
@@ -46,24 +47,24 @@ describe('MatchEndScreen view model', () => {
         {
           setNumber: 1,
           scores: {
-            'team-1': 6,
-            'team-2': 0
+            'team-1': { games: '6' },
+            'team-2': { games: '0' }
           },
           isSuperTiebreak: false
         },
         {
           setNumber: 2,
           scores: {
-            'team-1': 0,
-            'team-2': 6
+            'team-1': { games: '0' },
+            'team-2': { games: '6' }
           },
           isSuperTiebreak: false
         },
         {
           setNumber: 3,
           scores: {
-            'team-1': 6,
-            'team-2': 0
+            'team-1': { games: '6' },
+            'team-2': { games: '0' }
           },
           isSuperTiebreak: false
         }
@@ -94,8 +95,8 @@ describe('MatchEndScreen view model', () => {
         {
           setNumber: 1,
           scores: {
-            'team-1': 0,
-            'team-2': 0
+            'team-1': { games: '0' },
+            'team-2': { games: '0' }
           },
           isSuperTiebreak: false
         }
@@ -137,16 +138,16 @@ describe('MatchEndScreen view model', () => {
         {
           setNumber: 1,
           scores: {
-            'team-1': 6,
-            'team-2': 0
+            'team-1': { games: '6' },
+            'team-2': { games: '0' }
           },
           isSuperTiebreak: false
         },
         {
           setNumber: 2,
           scores: {
-            'team-1': 1,
-            'team-2': 1
+            'team-1': { games: '1' },
+            'team-2': { games: '1' }
           },
           isSuperTiebreak: false
         }
@@ -314,22 +315,46 @@ describe('MatchEndScreen view model', () => {
     expect(summary.setRows).toEqual([
       {
         setNumber: 1,
-        scores: { 'team-1': 6, 'team-2': 0 },
+        scores: { 'team-1': { games: '6' }, 'team-2': { games: '0' } },
         isSuperTiebreak: false
       },
       {
         setNumber: 2,
-        scores: { 'team-1': 0, 'team-2': 6 },
+        scores: { 'team-1': { games: '0' }, 'team-2': { games: '6' } },
         isSuperTiebreak: false
       },
       {
         setNumber: 3,
         scores: {
-          'team-1': defaultSuperTiebreakTargetPoints,
-          'team-2': defaultSuperTiebreakTargetPoints - 2
+          'team-1': { games: `${defaultSuperTiebreakTargetPoints}` },
+          'team-2': { games: `${defaultSuperTiebreakTargetPoints - 2}` }
         },
         isSuperTiebreak: true
       }
     ]);
+  });
+
+  test('formats completed standard tiebreak winner points in set rows', () => {
+    const projection = projectMatch(createTestSetup(), [
+      ...reachSixAll(),
+      ...repeatAction('team-1', 7),
+      ...repeatAction('team-2', 6),
+      ...scorePoints('team-1')
+    ]);
+
+    const summary = createMatchEndScreenSummary({
+      projection,
+      startedAt: 1_000,
+      finishedAt: 10_000
+    });
+
+    expect(summary.setRows[0]).toEqual({
+      setNumber: 1,
+      scores: {
+        'team-1': { games: '7', tiebreakPoints: '7' },
+        'team-2': { games: '6', tiebreakPoints: '0' }
+      },
+      isSuperTiebreak: false
+    });
   });
 });

--- a/test/components/MatchEndScreen/view-model.test.ts
+++ b/test/components/MatchEndScreen/view-model.test.ts
@@ -47,24 +47,24 @@ describe('MatchEndScreen view model', () => {
         {
           setNumber: 1,
           scores: {
-            'team-1': { games: '6' },
-            'team-2': { games: '0' }
+            'team-1': { score: '6' },
+            'team-2': { score: '0' }
           },
           isSuperTiebreak: false
         },
         {
           setNumber: 2,
           scores: {
-            'team-1': { games: '0' },
-            'team-2': { games: '6' }
+            'team-1': { score: '0' },
+            'team-2': { score: '6' }
           },
           isSuperTiebreak: false
         },
         {
           setNumber: 3,
           scores: {
-            'team-1': { games: '6' },
-            'team-2': { games: '0' }
+            'team-1': { score: '6' },
+            'team-2': { score: '0' }
           },
           isSuperTiebreak: false
         }
@@ -95,8 +95,8 @@ describe('MatchEndScreen view model', () => {
         {
           setNumber: 1,
           scores: {
-            'team-1': { games: '0' },
-            'team-2': { games: '0' }
+            'team-1': { score: '0' },
+            'team-2': { score: '0' }
           },
           isSuperTiebreak: false
         }
@@ -138,16 +138,16 @@ describe('MatchEndScreen view model', () => {
         {
           setNumber: 1,
           scores: {
-            'team-1': { games: '6' },
-            'team-2': { games: '0' }
+            'team-1': { score: '6' },
+            'team-2': { score: '0' }
           },
           isSuperTiebreak: false
         },
         {
           setNumber: 2,
           scores: {
-            'team-1': { games: '1' },
-            'team-2': { games: '1' }
+            'team-1': { score: '1' },
+            'team-2': { score: '1' }
           },
           isSuperTiebreak: false
         }
@@ -315,19 +315,19 @@ describe('MatchEndScreen view model', () => {
     expect(summary.setRows).toEqual([
       {
         setNumber: 1,
-        scores: { 'team-1': { games: '6' }, 'team-2': { games: '0' } },
+        scores: { 'team-1': { score: '6' }, 'team-2': { score: '0' } },
         isSuperTiebreak: false
       },
       {
         setNumber: 2,
-        scores: { 'team-1': { games: '0' }, 'team-2': { games: '6' } },
+        scores: { 'team-1': { score: '0' }, 'team-2': { score: '6' } },
         isSuperTiebreak: false
       },
       {
         setNumber: 3,
         scores: {
-          'team-1': { games: `${defaultSuperTiebreakTargetPoints}` },
-          'team-2': { games: `${defaultSuperTiebreakTargetPoints - 2}` }
+          'team-1': { score: `${defaultSuperTiebreakTargetPoints}` },
+          'team-2': { score: `${defaultSuperTiebreakTargetPoints - 2}` }
         },
         isSuperTiebreak: true
       }
@@ -351,8 +351,8 @@ describe('MatchEndScreen view model', () => {
     expect(summary.setRows[0]).toEqual({
       setNumber: 1,
       scores: {
-        'team-1': { games: '7', tiebreakPoints: '7' },
-        'team-2': { games: '6', tiebreakPoints: '0' }
+        'team-1': { score: '7', tiebreakPoints: '7' },
+        'team-2': { score: '6', tiebreakPoints: '0' }
       },
       isSuperTiebreak: false
     });

--- a/test/components/ShareScreen/ShareScreen.browser.test.tsx
+++ b/test/components/ShareScreen/ShareScreen.browser.test.tsx
@@ -9,8 +9,8 @@ describe('ShareScreen', () => {
     team2Name: 'Pablo y Thiago',
     formatLabel: 'Best of 3',
     setRows: [
-      { setNumber: 1, team1Games: 6, team2Games: 4 },
-      { setNumber: 2, team1Games: 7, team2Games: 5 }
+      { setNumber: 1, team1Games: { games: '6' }, team2Games: { games: '4' } },
+      { setNumber: 2, team1Games: { games: '7' }, team2Games: { games: '5' } }
     ],
     durationValue: '1h 22m',
     dateValue: '22/03/26'
@@ -35,6 +35,24 @@ describe('ShareScreen', () => {
     const screen = await render(<ShareScreen {...defaultProps} />);
     await expect.element(screen.getByText('6', { exact: true }).first()).toBeInTheDocument();
     await expect.element(screen.getByText('4', { exact: true }).first()).toBeInTheDocument();
+  });
+
+  it('renders formatted completed tiebreak winner score', async () => {
+    const screen = await render(
+      <ShareScreen
+        {...defaultProps}
+        setRows={[
+          {
+            setNumber: 1,
+            team1Games: { games: '7', tiebreakPoints: '8' },
+            team2Games: { games: '6', tiebreakPoints: '6' }
+          }
+        ]}
+      />
+    );
+
+    await expect.element(screen.getByText('(8)', { exact: true })).toBeInTheDocument();
+    await expect.element(screen.getByText('(6)', { exact: true })).toBeInTheDocument();
   });
 
   it('renders duration and date', async () => {

--- a/test/components/ShareScreen/ShareScreen.browser.test.tsx
+++ b/test/components/ShareScreen/ShareScreen.browser.test.tsx
@@ -9,8 +9,8 @@ describe('ShareScreen', () => {
     team2Name: 'Pablo y Thiago',
     formatLabel: 'Best of 3',
     setRows: [
-      { setNumber: 1, team1Games: { score: '6' }, team2Games: { score: '4' } },
-      { setNumber: 2, team1Games: { score: '7' }, team2Games: { score: '5' } }
+      { setNumber: 1, team1Score: { score: '6' }, team2Score: { score: '4' } },
+      { setNumber: 2, team1Score: { score: '7' }, team2Score: { score: '5' } }
     ],
     durationValue: '1h 22m',
     dateValue: '22/03/26'
@@ -44,8 +44,8 @@ describe('ShareScreen', () => {
         setRows={[
           {
             setNumber: 1,
-            team1Games: { score: '7', tiebreakPoints: '8' },
-            team2Games: { score: '6', tiebreakPoints: '6' }
+            team1Score: { score: '7', tiebreakPoints: '8' },
+            team2Score: { score: '6', tiebreakPoints: '6' }
           }
         ]}
       />

--- a/test/components/ShareScreen/ShareScreen.browser.test.tsx
+++ b/test/components/ShareScreen/ShareScreen.browser.test.tsx
@@ -9,8 +9,8 @@ describe('ShareScreen', () => {
     team2Name: 'Pablo y Thiago',
     formatLabel: 'Best of 3',
     setRows: [
-      { setNumber: 1, team1Games: { games: '6' }, team2Games: { games: '4' } },
-      { setNumber: 2, team1Games: { games: '7' }, team2Games: { games: '5' } }
+      { setNumber: 1, team1Games: { score: '6' }, team2Games: { score: '4' } },
+      { setNumber: 2, team1Games: { score: '7' }, team2Games: { score: '5' } }
     ],
     durationValue: '1h 22m',
     dateValue: '22/03/26'
@@ -44,8 +44,8 @@ describe('ShareScreen', () => {
         setRows={[
           {
             setNumber: 1,
-            team1Games: { games: '7', tiebreakPoints: '8' },
-            team2Games: { games: '6', tiebreakPoints: '6' }
+            team1Games: { score: '7', tiebreakPoints: '8' },
+            team2Games: { score: '6', tiebreakPoints: '6' }
           }
         ]}
       />

--- a/test/core/match/set-summary.test.ts
+++ b/test/core/match/set-summary.test.ts
@@ -22,8 +22,8 @@ describe('set summary formatter', () => {
     expect(getSetSummaryScores(set)).toEqual({ 'team-1': '7 (8)', 'team-2': '6 (6)' });
     expect(formatSetSummaryScore(set)).toBe('7 (8) - 6 (6)');
     expect(getSetSummaryScoreParts(set)).toEqual({
-      'team-1': { games: '7', tiebreakPoints: '8' },
-      'team-2': { games: '6', tiebreakPoints: '6' }
+      'team-1': { score: '7', tiebreakPoints: '8' },
+      'team-2': { score: '6', tiebreakPoints: '6' }
     });
   });
 

--- a/test/core/match/set-summary.test.ts
+++ b/test/core/match/set-summary.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  formatSetSummaryScore,
+  getSetSummaryScoreParts,
+  getSetSummaryScores
+} from '@/core/match/set-summary';
+import type { MatchSetState } from '@/core/match/types';
+
+describe('set summary formatter', () => {
+  test('shows both tiebreak point totals for completed standard tiebreak when team-1 wins', () => {
+    const set: MatchSetState = {
+      index: 1,
+      mode: 'standard',
+      firstServer: 'team-1',
+      completed: true,
+      winner: 'team-1',
+      games: { 'team-1': 7, 'team-2': 6 },
+      tiebreakPoints: { 'team-1': 8, 'team-2': 6 }
+    };
+
+    expect(getSetSummaryScores(set)).toEqual({ 'team-1': '7 (8)', 'team-2': '6 (6)' });
+    expect(formatSetSummaryScore(set)).toBe('7 (8) - 6 (6)');
+    expect(getSetSummaryScoreParts(set)).toEqual({
+      'team-1': { games: '7', tiebreakPoints: '8' },
+      'team-2': { games: '6', tiebreakPoints: '6' }
+    });
+  });
+
+  test('shows both tiebreak point totals when team-2 wins', () => {
+    const set: MatchSetState = {
+      index: 2,
+      mode: 'standard',
+      firstServer: 'team-2',
+      completed: true,
+      winner: 'team-2',
+      games: { 'team-1': 6, 'team-2': 7 },
+      tiebreakPoints: { 'team-1': 8, 'team-2': 10 }
+    };
+
+    expect(formatSetSummaryScore(set)).toBe('6 (8) - 7 (10)');
+  });
+
+  test('keeps plain score for non-tiebreak standard sets', () => {
+    const set: MatchSetState = {
+      index: 1,
+      mode: 'standard',
+      firstServer: 'team-1',
+      completed: true,
+      winner: 'team-1',
+      games: { 'team-1': 6, 'team-2': 4 },
+      tiebreakPoints: null
+    };
+
+    expect(formatSetSummaryScore(set)).toBe('6 - 4');
+  });
+
+  test('keeps super tiebreak behavior using completed tiebreak points', () => {
+    const set: MatchSetState = {
+      index: 3,
+      mode: 'super-tiebreak',
+      firstServer: 'team-1',
+      completed: true,
+      winner: 'team-1',
+      games: { 'team-1': 1, 'team-2': 0 },
+      tiebreakPoints: { 'team-1': 11, 'team-2': 9 }
+    };
+
+    expect(formatSetSummaryScore(set)).toBe('11 - 9');
+  });
+
+  test('does not show completed tiebreak winner notation early for in-progress sets', () => {
+    const set: MatchSetState = {
+      index: 1,
+      mode: 'standard',
+      firstServer: 'team-1',
+      completed: false,
+      games: { 'team-1': 6, 'team-2': 6 },
+      game: {
+        kind: 'tiebreak',
+        targetPoints: 7,
+        points: { 'team-1': 5, 'team-2': 4 }
+      }
+    };
+
+    expect(formatSetSummaryScore(set)).toBe('6 - 6');
+  });
+
+  test('falls back to plain score when legacy completed tiebreak has null tiebreakPoints', () => {
+    const set: MatchSetState = {
+      index: 1,
+      mode: 'standard',
+      firstServer: 'team-1',
+      completed: true,
+      winner: 'team-1',
+      games: { 'team-1': 7, 'team-2': 6 },
+      tiebreakPoints: null
+    };
+
+    expect(formatSetSummaryScore(set)).toBe('7 - 6');
+  });
+});


### PR DESCRIPTION
## Summary

Display complete tiebreak point scores (e.g. `7 (8)` vs `6 (6)`) in all set summary views — Match End, History, Sets History Modal, and Share screen — so players can see the exact tiebreak points for each set, not just the game count.

## What was added

- **`src/core/match/set-summary.ts`** — new pure utility module with `getSetSummaryScoreParts()` and `formatSetSummaryScorePart()` to extract and format tiebreak-aware score parts from any set state
- **`src/components/SetScoreValue/SetScoreValue.tsx`** — reusable component that renders a score value with an optional tiebreak points when the set was won via tiebreak
- **`src/components/MatchEndScreen/MatchSummaryCard`** — uses `SetScoreValue` for visual score + `formatSetSummaryScorePart` for screen reader text
- **`src/components/HistoryScreen/HistoryScreen`** — games column now renders per-set scores inline using `SetScoreValue`, with tiebreak visible at a glance
- **`src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal`** — modal set list now shows tiebreak points alongside game scores
- **`src/components/ShareScreen/ShareScreen`** — share image includes tiebreak points in set summaries
- **`src/components/MatchEndScreen/view-model`** — view model updated to use `getSetSummaryScoreParts` for tiebreak-aware scoring
- **CSS modules** for all affected components — added `.tiebreakPoints` styles using design tokens

## Test results

- ✅ 103 test files, 1128 tests passing
- ✅ 89.11% statements, 81% branches, 89.02% functions, 89.54% lines
- ✅ New unit tests for `set-summary.ts` (102 lines, covering tiebreak/super-tiebreak/regular scenarios)
- ✅ Updated browser tests for HistoryScreen, MatchEndScreen, SetsHistoryModal, ShareScreen
- ✅ E2E specs updated for new score format