### PR TITLE
feat: mirror scoreboard team columns when side switch is due

### DIFF
--- a/docs/development-logs/Task PBW-113 Mirror Active Match Scoreboard When Side Switch Is Due.md
+++ b/docs/development-logs/Task PBW-113 Mirror Active Match Scoreboard When Side Switch Is Due.md
@@ -1,0 +1,103 @@
+---
+title: PBW-113 Mirror Active Match Scoreboard When Side Switch Is Due
+type: development-log
+permalink: docs/development-logs/task-PBW-113-mirror-active-match-scoreboard-when-side-switch-is-due
+---
+
+# Development Log: PBW-113
+
+## Metadata
+
+- Task ID: PBW-113
+- Date (UTC): 2026-06-02T14:04:34Z
+- Project: padelbuddy-web
+- Branch: feature/PBW-113-mirror-active-match-scoreboard-when-side-switch-is-due
+- Commit: 73148aa (merged into main)
+
+## Objective
+
+- Mirror the active match scoreboard visual team order when a side switch is due, so players see the physical court sides reflected on screen.
+- Derive `isScoreboardMirrored` state purely from existing match data (no new persisted state).
+- Propagate the mirrored visual order across TeamPanel columns, SetsCard, and SetsHistoryModal.
+- Handle legacy super-tiebreak fallback for mirror parity computation.
+- Ensure persistence recovery and E2E startup timing are stable under mirrored layout.
+- Final QA gate green across unit, browser, and E2E test suites.
+
+## Implementation Summary
+
+- **Derived mirrored scoreboard state (`isScoreboardMirrored`)**: Added `isScoreboardMirrored: boolean` to `MatchDerivedState` in `derived-state.ts`. Computed as `getMatchSideSwitchCount(state) % 2 === 1` when `setup.sideSwitchPrompts` is `true`; `false` otherwise. Side-switch count is cumulative across completed sets (using standard game count + tiebreak switch intervals) and the active set. This is a derived-only computation — no new persisted fields, no new actions. Parity flips every odd game boundary and every 6 tiebreak points.
+
+- **Visible-column interaction mapping (`visualTeamOrder`)**: `ActiveMatchScreen` reads `derived.isScoreboardMirrored` and produces `visualTeamOrder` as either `['team-1', 'team-2']` (normal) or `['team-2', 'team-1']` (mirrored). This order drives: (1) TeamPanel column layout via `teamColumns.map()`, (2) SetsCard current-set score display via `getSetDisplayScore(set, visualTeamOrder)`, (3) SetsHistoryModal completed-set rows via `reorderVisualTeamScore()`. Scoring clicks on visible columns map back to real team IDs — speech announcements always use real team IDs, not visual order.
+
+- **`VisualTeamOrder` type and helpers**: Introduced `VisualTeamOrder` type (`readonly [MatchTeamId, MatchTeamId]`) and `DEFAULT_VISUAL_TEAM_ORDER` in `sets-history.ts`. Added `reorderVisualTeamScore<Value>()` generic helper that remaps any `TeamScore<Value>` into the visual team order. All display helpers (`getSetDisplayScore`, `getSetsWonScore`) accept optional `visualTeamOrder` parameter.
+
+- **Legacy super-tiebreak fallback/parity handling**: `getMatchSideSwitchCount` counts side switches cumulatively across sets. For completed sets, it uses standard game count + tiebreak switch intervals. For the active set, it adds ongoing game/tiebreak switches. Legacy super-tiebreak sets that lack `tiebreakPoints` (pre-schema matches) recover parity via the active-set's `game.points` shape through `getActiveSetSideSwitchCount`. The `getCompletedSetTiebreakPoints` helper provides the fallback chain: `tiebreakPoints ?? game.points ?? games`.
+
+- **Persistence legacy side-switch fallback**: `persistence.ts` already had `shouldUseLegacySideSwitchPrompts` (broadened in PBW-102 to cover both in-progress and completed records). Legacy records missing `sideSwitchPrompts` default to `true`, so pre-PBW-113 matches correctly compute mirror parity.
+
+- **E2E stability fixes for persistence recovery/startup timing**: Added `expectVisualTeamOrder` helper to `persistence-recovery.edge-case.spec.ts` that polls `data-testid` attributes to confirm visual column order. Added mirrored-resume E2E test that seeds a match with 4 team-1 points (1 game won, mirrored state), resumes it, verifies prompt + mirrored layout, dismisses prompt, reloads, and confirms layout persists without prompt. Introduced `gotoHomeAndWaitForVisible` retry loop with per-attempt timeout (8s) + total budget (26s) to handle cold-start IndexedDB timing. `dismissSideSwitchPromptIfVisible` helper added to `match-flow.ts` for reusable prompt dismissal.
+
+- **Unit tests for mirror parity**: `serve-derived-state.test.ts` covers: side-switch prompts from odd games + tiebreak intervals, cumulative parity across set boundaries (6-0 → mirrored, 6-0+1 → unmirrored, 7-5 → unmirrored), standard tiebreak set parity (7-6 → odd total games, next-set prompt, parity unmirrored), side-switch prompts off disables mirroring, legacy super-tiebreak parity recovery.
+
+- **Browser tests for mirrored UI**: `ActiveMatchScreen.browser.test.tsx` covers: mirrored visual order persists after dismissing side-switch prompt, mirrored visible columns for scoring (speech payload stays on real team IDs), mirrored revert button with tiebreak parity recomputation after undo. Helper functions: `readVisualTeamOrder`, `getVisibleTeamPanel`, `getVisibleRevertButton`, `readDisplayedScore`. `SetsCard.browser.test.tsx` covers mirrored current-set score and accessible label. `SetsHistoryModal.browser.test.tsx` covers mirrored headline and completed-set rows.
+
+- **Final QA gate**: `pnpm complete-check` green — lint, format, type-check, unit, browser, E2E all passing.
+
+## Files Changed
+
+### Core Engine
+
+- `src/core/match/derived-state.ts` — Added `isScoreboardMirrored()` function and `isScoreboardMirrored` field to `deriveMatchState` output; cumulative `getMatchSideSwitchCount` across set boundaries
+- `src/core/match/types.ts` — Added `isScoreboardMirrored: boolean` to `MatchDerivedState`
+
+### Display Components
+
+- `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx` — Reads `isScoreboardMirrored`, computes `visualTeamOrder`, maps to `teamColumns` for TeamPanel/SetsCard/SetsHistoryModal, scoring and revert buttons use visible-column mapping
+- `src/components/ActiveMatchScreen/SetsCard/SetsCard.tsx` — Accepts `visualTeamOrder` prop, passes to `getSetDisplayScore`
+- `src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx` — Accepts `visualTeamOrder` prop, passes to `getSetsWonScore` and `reorderVisualTeamScore`
+- `src/components/ActiveMatchScreen/sets-history.ts` — Added `VisualTeamOrder` type, `DEFAULT_VISUAL_TEAM_ORDER`, `reorderVisualTeamScore<Value>()` generic; updated `getSetDisplayScore`, `getSetsWonScore` to accept optional `visualTeamOrder`
+
+### Persistence
+
+- `src/lib/current-match/persistence.ts` — Legacy `sideSwitchPrompts` fallback (already from PBW-102, confirmed compatible with mirror parity)
+
+### Unit Tests
+
+- `test/core/match/serve-derived-state.test.ts` — Mirror parity tests: odd-games, tiebreak-interval, cumulative set-boundary parity, standard tiebreak set parity, side-switch-off disables mirroring, legacy super-tiebreak recovery
+- `test/components/ActiveMatchScreen/sets-history.test.ts` — `reorderVisualTeamScore` tests, mirrored display score, mirrored sets-won, mirrored set summary parts
+
+### Browser Tests
+
+- `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx` — Mirrored visual order after dismiss, mirrored scoring columns with speech verification, mirrored revert button with undo parity recomputation
+- `test/components/ActiveMatchScreen/SetsCard.browser.test.tsx` — Mirrored current-set score and accessible label
+- `test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx` — Mirrored headline and completed-set rows
+
+### E2E Tests
+
+- `e2e/active-match.happy-path.spec.ts` — Scoring flow with side-switch prompts, visual team order assertion after game win, prompt dismissal
+- `e2e/persistence-recovery.edge-case.spec.ts` — Mirrored-resume test: seed 4 team-1 points, resume, verify prompt + mirrored layout, dismiss, reload, verify persisted layout; `expectVisualTeamOrder` helper with polling
+- `e2e/helpers/match-flow.ts` — `dismissSideSwitchPromptIfVisible` helper, `sideSwitchPrompts` option in `startMatch`
+
+## Key Decisions
+
+- **Derived-only state**: `isScoreboardMirrored` is computed purely from existing match state. No new persisted fields, no new action types. Keeps persistence schema stable and mirror logic deterministic from replay.
+- **Cumulative parity across sets**: Side-switch count aggregates completed-set switches + active-set switches. Parity (`% 2`) determines mirror state. This matches real padel rules where side switches accumulate across the match.
+- **Visual order as a mapping layer**: `visualTeamOrder` is a display-time transformation. Real team IDs (`team-1`, `team-2`) remain the source of truth for scoring, persistence, speech, and share. Visual order only affects DOM column order and score label remapping.
+- **Generic `reorderVisualTeamScore<Value>`**: Single generic function handles all score types (numbers, strings, SetSummaryScorePart objects). Avoids per-type reordering functions.
+- **Legacy super-tiebreak parity recovery**: Pre-schema matches missing `tiebreakPoints` recover parity via `getCompletedSetTiebreakPoints` fallback chain (`tiebreakPoints ?? game.points`). Ensures older matches compute mirror state correctly.
+- **E2E polling for visual order**: `expectVisualTeamOrder` uses `expect.poll()` instead of direct assertions — React async rendering can cause brief frame where DOM hasn't reordered yet.
+- **E2E retry budget pattern**: `gotoHomeAndWaitForVisible` uses per-attempt timeout (8s) + total budget (26s) pattern (consistent with PBW-102's setup-screen fix). Handles cold-start IndexedDB timing without flaky failures.
+
+## Validation Performed
+
+- `pnpm complete-check` — **PASSES** (lint, format, type-check, unit, browser, E2E all green)
+- Code review — **APPROVED**
+- Architecture review — **APPROVED**
+- Copilot PR review — feedback incorporated (legacy completed-match side-switch fallback broadened)
+
+## Risks and Follow-ups
+
+- Mirror state is derived from cumulative side-switch count — if side-switch counting rules change (e.g., different intervals for different formats), `getMatchSideSwitchCount` must be updated.
+- Legacy super-tiebreak fallback (`tiebreakPoints ?? game.points ?? games`) can be removed once all pre-tiebreakPoints matches have expired from user devices.
+- E2E does not test mirror state across a full multi-set match (only single-set and resume scenarios) — browser tests cover the cumulative parity logic.
+- Visual order polling adds ~100ms latency to E2E assertions — acceptable trade-off for stability.

--- a/docs/plan/Plan PBW-113 Mirror active match scoreboard when side switch is due.md
+++ b/docs/plan/Plan PBW-113 Mirror active match scoreboard when side switch is due.md
@@ -1,0 +1,165 @@
+## Task Analysis
+
+- Main objective:
+  - Deliver PBW-113 by mirroring the active-match visual left/right order whenever a rules-based side switch is due, while keeping the change fully derived from existing match setup + replayed match state.
+  - Scope: active match flow only. Mirror must apply to the two live team columns, per-team revert controls, serving highlight, `SetsCard`, and `SetsHistoryModal`.
+  - Guardrails already locked by user:
+    - no persistence schema/API change unless code proves impossible
+    - no animation; swap snaps instantly
+    - visible column is source of truth for touch interactions
+    - mirrored layout persists after prompt dismissal and follows derived parity, not modal visibility
+    - one current live visual mapping must be reused across older completed sets shown in summary/history
+    - match-end screen unchanged
+    - audio/toasts/non-visual team references remain bound to real team IDs
+- Identified dependencies:
+  - Core side-switch derivation:
+    - `src/core/match/derived-state.ts`
+    - `src/core/match/types.ts`
+  - Active match presentation:
+    - `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx`
+    - `src/components/ActiveMatchScreen/SetsCard/SetsCard.tsx`
+    - `src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx`
+    - `src/components/ActiveMatchScreen/sets-history.ts`
+    - `src/components/ActiveMatchScreen/TeamPanel/TeamPanel.tsx` (read-only dependency; behavior should be reused, not redesigned)
+  - Relevant test coverage already in place:
+    - `test/core/match/serve-derived-state.test.ts`
+    - `test/components/ActiveMatchScreen/sets-history.test.ts`
+    - `test/components/ActiveMatchScreen/SetsCard.browser.test.tsx`
+    - `test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx`
+    - `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx`
+    - `e2e/active-match.happy-path.spec.ts`
+    - `e2e/persistence-recovery.edge-case.spec.ts`
+    - `e2e/helpers/persistence.ts` (only if existing seeding cannot express mirrored resume state cleanly)
+- System impact:
+  - No persistence, router, speech-service, or match-end changes expected.
+  - Small core-model expansion expected: add one derived mirror/parity signal to `MatchDerivedState`, then thread one resolved visual order through active-match UI.
+  - No i18n copy change expected; existing labels can be reused with reordered values.
+  - Important implementation nuance: mirror parity cannot be inferred from `sideSwitch.shouldPrompt` or from completed-set odd/even totals alone. Example: a 6-0 set has an even total game count but leaves players visually swapped because switches happened after games 1, 3, and 5.
+  - Plan file: `/Users/trystan2k/Documents/Thiago/Repos/padelbuddy-web/docs/plan/Plan PBW-113 Mirror active match scoreboard when side switch is due.md`
+
+## Chosen Approach
+
+- Proposed solution:
+  - Add one pure derived boolean in core match projection, e.g. `derived.isScoreboardMirrored`, computed from cumulative side-switch parity across the full replayed match state.
+  - Reuse current side-switch timing rules by factoring shared helpers in `derived-state.ts`:
+    - standard-game switch due at odd completed games; cumulative count = `Math.floor((completedGames + 1) / 2)`
+    - tiebreak switch due every 6 played points; cumulative count = `Math.floor(pointsPlayed / 6)`
+  - In `ActiveMatchScreen.tsx`, resolve one current visual order tuple from that boolean, e.g. `[leftTeamId, rightTeamId]`, and use it everywhere in the active-match UI.
+  - Pass that same visual order into `SetsCard` and `SetsHistoryModal`, with tiny shared reorder helpers in `sets-history.ts`, so older completed sets are shown in current live visual order instead of historical per-set sides.
+  - Keep prompt visibility state (`sideSwitchDismissed`) separate from mirror parity. Dismissing the prompt only closes the modal; it must not affect layout.
+- Justification for simplicity:
+  - Keeps source of truth in existing replay/derived-state pipeline. Undo, reload, and resume then work automatically from persisted actions without new storage.
+  - Limits UI changes to active-match presentation files already responsible for left/right rendering.
+  - Avoids coupling layout to prompt modal lifecycle, which would fail the persistence-after-dismiss requirement.
+  - Avoids persisting a visual-side flag, which would be redundant and fragile.
+  - Rejected approach 1: compute mirroring from `sideSwitch.shouldPrompt` or dismissed modal state in `ActiveMatchScreen`. Rejected because layout must persist between prompt moments and across reload.
+  - Rejected approach 2: persist current visual side in IndexedDB/API. Rejected because user explicitly wants derived-only behavior and current replay model is enough.
+  - Rejected approach 3: reconstruct historical left/right per completed set in summary/history. Rejected because user explicitly wants one current live mapping across the whole active-match UI.
+- Components to be modified/created:
+  - Core:
+    - `src/core/match/types.ts` — add derived mirror flag type
+    - `src/core/match/derived-state.ts` — compute cumulative side-switch parity and keep prompt logic on same helper math
+  - Active-match UI:
+    - `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx` — render columns from resolved visual order; keep remote/audio logic on real team IDs
+    - `src/components/ActiveMatchScreen/sets-history.ts` — add tiny score-reordering helpers for current visual order
+    - `src/components/ActiveMatchScreen/SetsCard/SetsCard.tsx` — accept visual order and render mirrored current-set summary/ARIA label
+    - `src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx` — accept visual order and render mirrored sets-won headline + row scores
+  - Tests:
+    - `test/core/match/serve-derived-state.test.ts`
+    - `test/components/ActiveMatchScreen/sets-history.test.ts`
+    - `test/components/ActiveMatchScreen/SetsCard.browser.test.tsx`
+    - `test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx`
+    - `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx`
+    - `e2e/active-match.happy-path.spec.ts`
+    - `e2e/persistence-recovery.edge-case.spec.ts`
+    - `e2e/helpers/persistence.ts` only if minimal seed overrides are needed
+
+## Implementation Steps
+
+1. Extend core derived state with cumulative mirror parity.
+   - In `src/core/match/types.ts`, add one derived field for layout parity, preferably `isScoreboardMirrored: boolean`.
+   - In `src/core/match/derived-state.ts`, factor small shared helpers for:
+     - standard side-switch due/count
+     - tiebreak side-switch due/count
+     - cumulative match-wide side-switch count across completed sets plus active set
+   - Compute mirror parity from total switch count `% 2 === 1`, gated by `setup.sideSwitchPrompts` so disabled prompts keep the current fixed layout.
+   - Keep `getSideSwitchState()` using the same helper math; do not fork separate rules.
+   - File-by-file test update:
+     - extend `test/core/match/serve-derived-state.test.ts` with cases for odd-game parity, 6-point tiebreak parity, cross-set accumulation, 6-0/7-5 style boundary behavior, disabled-prompts false path, and replay/undo recomputation via shorter action lists.
+   - Risk note:
+     - Biggest correctness risk lives here. If parity math is wrong, every screen stays wrong after reload. Mitigation: lock formulas with explicit tests before wiring UI.
+
+2. Resolve one visual team order in `ActiveMatchScreen` and thread it through all active-match presentation.
+   - In `src/components/ActiveMatchScreen/ActiveMatchScreen.tsx`, derive one tuple from the new boolean, e.g. `[leftTeamId, rightTeamId]`, then render both team columns from that order instead of hardcoding team 1 left / team 2 right.
+   - Keep `TeamPanel` props tied to the real team being rendered in each column so scoring, revert, and serving highlight all move together automatically.
+   - Keep `useMatchAnnouncements`, keyboard shortcuts, media-button remote actions, toasts, and other non-visual references on real underlying team IDs. Only visible touch targets change side.
+   - Pass the resolved visual order into:
+     - `src/components/ActiveMatchScreen/SetsCard/SetsCard.tsx`
+     - `src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx`
+   - In `src/components/ActiveMatchScreen/sets-history.ts`, add tiny helpers that reorder:
+     - current set display score
+     - sets-won headline score
+     - completed set summary row parts
+       using the same current visual order tuple.
+   - Keep CSS untouched unless a hidden nth-child/layout assumption appears; current modules look symmetric enough to prefer no style churn.
+   - Risk note:
+     - Existing stable test IDs are keyed by real team IDs (`team-panel-team-1`, `revert-button-team-2`). Keep those IDs stable and change only DOM order. That minimizes selector churn and preserves non-visual semantics.
+
+3. Update browser + Playwright coverage around mirrored interactions, summary/history order, and resume behavior.
+   - `test/components/ActiveMatchScreen/SetsCard.browser.test.tsx`
+     - add mirrored-order case so current set score/accessible label flips with visual order.
+   - `test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx`
+     - add mirrored-order case so overall sets headline and completed rows follow current visual order, not historical team-1/team-2 order.
+   - `test/components/ActiveMatchScreen/sets-history.test.ts`
+     - add focused unit tests for any new reorder helpers.
+   - `test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx`
+     - add/adjust integration tests for:
+       - odd-game mirror after first due switch
+       - prompt dismissal does not unmirror layout
+       - left visible column scores the team currently shown on the left
+       - left visible revert undoes that same underlying team
+       - serving highlight moves with the mirrored column
+       - speech payload stays bound to real team IDs after mirrored scoring
+       - tiebreak 6-point mirror parity and undo recomputation
+   - `e2e/active-match.happy-path.spec.ts`
+     - update side-switch-enabled flow to assert mirrored active-match UI after first game, including `SetsCard` order and persistence after dismissing the prompt.
+   - `e2e/persistence-recovery.edge-case.spec.ts`
+     - add mirrored resume/reload scenario with side-switch prompts enabled so a persisted in-progress record resumes into the correct mirrored layout and stays correct after reload.
+   - `e2e/helpers/persistence.ts`
+     - only if needed, add minimal optional setup/action overrides so the persistence spec can seed an odd-game or tiebreak mirror state without duplicating IndexedDB write logic.
+   - Rollback note:
+     - If generic Playwright seed-helper expansion starts growing, stop and keep the new seed logic local to `persistence-recovery.edge-case.spec.ts`. Do not over-abstract test seeding for one scenario.
+
+## Validation
+
+- Success criteria:
+  - Active-match team columns mirror instantly and only when `sideSwitchPrompts` is enabled.
+  - Mirror parity is derived purely from replayed match state; no persistence schema/API change is introduced.
+  - Standard-play parity matches cumulative odd-game switches across the full match, including set boundaries.
+  - Tiebreak parity flips every 6 points and accumulates across the match.
+  - Dismissing the side-switch prompt does not affect layout.
+  - Left visible touch targets score/undo the team currently shown on the left; same for right side.
+  - `SetsCard` and `SetsHistoryModal` use the same current live visual order, including older completed sets.
+  - Undo, reload, and resume recompute the correct layout from persisted setup/actions.
+  - Match-end screen behavior stays unchanged.
+  - Audio announcements and other non-visual team references remain tied to real team IDs.
+- Checkpoints:
+  - Pre-implementation assumptions check:
+    - grep active-match files for any remaining hardcoded team-1-left/team-2-right rendering outside `ActiveMatchScreen`, `SetsCard`, and `SetsHistoryModal`
+    - confirm side-switch-disabled flows remain intentionally unchanged
+  - After Step 1:
+    - `test/core/match/serve-derived-state.test.ts` passes with explicit parity coverage, especially 6-0 and tiebreak interval edge cases
+    - no persistence or router files touched
+  - After Step 2:
+    - browser tests prove DOM order swap, mirrored summary/history order, and visible-column interaction mapping
+    - no i18n diff and no match-end diff
+  - After Step 3:
+    - Playwright proves mirrored layout in real browser flow after side-switch prompt and after resume/reload
+    - targeted suites pass before full QA:
+      - `pnpm vitest test/core/match/serve-derived-state.test.ts`
+      - `pnpm vitest test/components/ActiveMatchScreen/sets-history.test.ts`
+      - `pnpm vitest test/components/ActiveMatchScreen/SetsCard.browser.test.tsx`
+      - `pnpm vitest test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx`
+      - `pnpm vitest test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx`
+      - `pnpm playwright test e2e/active-match.happy-path.spec.ts e2e/persistence-recovery.edge-case.spec.ts`
+    - final regression gate: `pnpm complete-check`

--- a/e2e/active-match.happy-path.spec.ts
+++ b/e2e/active-match.happy-path.spec.ts
@@ -28,11 +28,25 @@ test.describe('@happy-path @active-match Active match', () => {
     await expect(team1Panel).toContainText('40');
 
     await team1Panel.click();
-    await expect(page.getByTestId('set-row-current')).toContainText('1-0');
+    await expect(page.getByTestId('set-row-current')).toContainText('0-1');
     await expect(page.getByTestId('side-switch-prompt')).toBeVisible();
+    await expect
+      .poll(async () => {
+        return page.locator('[data-testid^="team-panel-"]').evaluateAll((elements) => {
+          return elements.map((element) => element.getAttribute('data-testid'));
+        });
+      })
+      .toEqual(['team-panel-team-2', 'team-panel-team-1']);
 
     await dismissSideSwitchPromptIfVisible(page);
     await expect(page.getByTestId('side-switch-prompt')).toBeHidden();
+    await expect
+      .poll(async () => {
+        return page.locator('[data-testid^="team-panel-"]').evaluateAll((elements) => {
+          return elements.map((element) => element.getAttribute('data-testid'));
+        });
+      })
+      .toEqual(['team-panel-team-2', 'team-panel-team-1']);
   });
 
   test('completes a full match and reaches the finish route', async ({ page }) => {

--- a/e2e/helpers/persistence.ts
+++ b/e2e/helpers/persistence.ts
@@ -30,6 +30,8 @@ interface SeedMatchOptions {
   team2Name?: string;
   startedAt?: number;
   finishedAt?: number;
+  setupOverrides?: Partial<MatchSetupInput>;
+  actions?: MatchAction[];
 }
 
 const defaultSides: MatchSetupInput['sides'] = [
@@ -123,6 +125,8 @@ async function putRecord(page: Page, record: unknown): Promise<void> {
       value: record
     }
   );
+
+  await page.goto('about:blank');
 }
 
 function buildCompletedMatchRecord(options: SeedMatchOptions = {}): CurrentMatchRecord {
@@ -153,7 +157,9 @@ function buildInProgressMatchRecord(options: SeedMatchOptions = {}): CurrentMatc
     matchId = 'in-progress-match',
     team1Name = 'Team A',
     team2Name = 'Team B',
-    startedAt = defaultStartedAt
+    startedAt = defaultStartedAt,
+    setupOverrides,
+    actions = [...createScoreActions('team-1', 4), ...createScoreActions('team-2', 2)]
   } = options;
 
   return createCurrentMatchRecord({
@@ -161,12 +167,13 @@ function buildInProgressMatchRecord(options: SeedMatchOptions = {}): CurrentMatc
     startedAt,
     setup: createSetup({
       format: 'best-of-3',
+      ...setupOverrides,
       sides: [
         { id: 'team-1', playerNames: [team1Name] },
         { id: 'team-2', playerNames: [team2Name] }
       ]
     }),
-    actions: [...createScoreActions('team-1', 4), ...createScoreActions('team-2', 2)]
+    actions
   });
 }
 

--- a/e2e/persistence-recovery.edge-case.spec.ts
+++ b/e2e/persistence-recovery.edge-case.spec.ts
@@ -55,7 +55,7 @@ async function gotoHomeAndWaitForVisible(page: Page, locator: Locator): Promise<
     const readinessTimeoutMs = Math.min(startupReadyAttemptTimeoutMs, remainingBudgetMs);
 
     try {
-      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await page.goto('/', { waitUntil: 'domcontentloaded', timeout: readinessTimeoutMs });
       await expect(locator).toBeVisible({ timeout: readinessTimeoutMs });
     } catch (error) {
       const isLastAttempt = attempt === maxStartupNavigationAttempts;

--- a/e2e/persistence-recovery.edge-case.spec.ts
+++ b/e2e/persistence-recovery.edge-case.spec.ts
@@ -1,3 +1,5 @@
+import type { Locator, Page } from '@playwright/test';
+
 import { expect, test } from './fixtures';
 
 import {
@@ -7,13 +9,103 @@ import {
   seedSchemaMismatchRecord
 } from './helpers/persistence';
 
+const mirroredResumeActions = Array.from({ length: 4 }, () => ({
+  type: 'score-point' as const,
+  teamId: 'team-1' as const
+}));
+
+const startupReadyAttemptTimeoutMs = 8_000;
+const startupReadyBudgetMs = 26_000;
+const maxStartupNavigationAttempts = 3;
+
+function isTransientNavigationError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return (
+    message.includes('ERR_CONNECTION_REFUSED') ||
+    message.includes('ERR_CONNECTION_RESET') ||
+    message.includes('ERR_NETWORK_CHANGED') ||
+    message.includes('ECONNREFUSED') ||
+    message.includes('Navigation timeout')
+  );
+}
+
+function isRetryableStartupReadinessError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return (
+    message.includes('expect(locator).toBeVisible() failed') ||
+    message.includes('element(s) not found')
+  );
+}
+
+async function gotoHomeAndWaitForVisible(page: Page, locator: Locator): Promise<void> {
+  const startedAt = Date.now();
+
+  async function navigate(attempt: number): Promise<void> {
+    const elapsedMs = Date.now() - startedAt;
+    const remainingBudgetMs = startupReadyBudgetMs - elapsedMs;
+
+    if (remainingBudgetMs <= 0) {
+      throw new Error(
+        `Home startup UI not ready within ${String(startupReadyBudgetMs)}ms total retry budget.`
+      );
+    }
+
+    const readinessTimeoutMs = Math.min(startupReadyAttemptTimeoutMs, remainingBudgetMs);
+
+    try {
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await expect(locator).toBeVisible({ timeout: readinessTimeoutMs });
+    } catch (error) {
+      const isLastAttempt = attempt === maxStartupNavigationAttempts;
+      const nextAttemptElapsedMs = Date.now() - startedAt;
+      const hasBudgetForRetry = nextAttemptElapsedMs < startupReadyBudgetMs;
+
+      if (
+        isLastAttempt ||
+        !hasBudgetForRetry ||
+        (!isTransientNavigationError(error) && !isRetryableStartupReadinessError(error))
+      ) {
+        throw error;
+      }
+
+      await page.waitForTimeout(250 * attempt);
+      await navigate(attempt + 1);
+    }
+  }
+
+  await navigate(1);
+}
+
+async function expectVisualTeamOrder(
+  page: Page,
+  expectedOrder: readonly [
+    'team-panel-team-1' | 'team-panel-team-2',
+    'team-panel-team-1' | 'team-panel-team-2'
+  ]
+) {
+  const teamPanels = page.locator('[data-testid^="team-panel-"]');
+
+  await expect(teamPanels).toHaveCount(2);
+  await expect
+    .poll(async () => {
+      return Promise.all([
+        teamPanels.nth(0).getAttribute('data-testid'),
+        teamPanels.nth(1).getAttribute('data-testid')
+      ]);
+    })
+    .toEqual([...expectedOrder]);
+}
+
 test.describe('@edge-case @setup @active-match @match-end Persistence recovery', () => {
   test('shows the resume or discard dialog for an in-progress record', async ({ page }) => {
     await seedInProgressMatchRecord(page);
 
-    await page.goto('/');
-
-    await expect(page.getByRole('heading', { name: /resume saved match/i })).toBeVisible();
+    await gotoHomeAndWaitForVisible(
+      page,
+      page.getByRole('heading', { name: /resume saved match/i })
+    );
     await page.getByRole('button', { name: /discard match/i }).click();
 
     await expect(page).toHaveURL('/');
@@ -29,7 +121,7 @@ test.describe('@edge-case @setup @active-match @match-end Persistence recovery',
   }) => {
     const record = await seedInProgressMatchRecord(page, { matchId: 'resumable-match' });
 
-    await page.goto('/');
+    await gotoHomeAndWaitForVisible(page, page.getByRole('button', { name: /resume match/i }));
     await page.getByRole('button', { name: /resume match/i }).click();
 
     await expect(page).toHaveURL(new RegExp(`/match/${record.matchId}$`));
@@ -40,12 +132,42 @@ test.describe('@edge-case @setup @active-match @match-end Persistence recovery',
     await expect(page.getByRole('heading', { name: /resume saved match/i })).toHaveCount(0);
   });
 
+  test('resumes and reloads into the same mirrored layout when side switch parity is due', async ({
+    page
+  }) => {
+    const record = await seedInProgressMatchRecord(page, {
+      matchId: 'mirrored-resume-match',
+      setupOverrides: {
+        sideSwitchPrompts: true
+      },
+      actions: mirroredResumeActions
+    });
+
+    await gotoHomeAndWaitForVisible(page, page.getByRole('button', { name: /resume match/i }));
+    await page.getByRole('button', { name: /resume match/i }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/match/${record.matchId}$`));
+    await expect(page.getByTestId('side-switch-prompt')).toBeVisible();
+    await expect(page.getByTestId('set-row-current')).toContainText('0-1');
+    await expectVisualTeamOrder(page, ['team-panel-team-2', 'team-panel-team-1']);
+
+    await page.getByRole('button', { name: /switched/i }).click();
+    await expect(page.getByTestId('side-switch-prompt')).toBeHidden();
+
+    await page.reload();
+    await expect(page).toHaveURL(new RegExp(`/match/${record.matchId}$`));
+    await expect(page.getByRole('heading', { name: /resume saved match/i })).toHaveCount(0);
+    await expect(page.getByTestId('set-row-current')).toContainText('0-1');
+    await expectVisualTeamOrder(page, ['team-panel-team-2', 'team-panel-team-1']);
+  });
+
   test('recovers from a corrupt record and clears persistence after reset', async ({ page }) => {
     await seedInvalidCurrentMatchRecord(page);
 
-    await page.goto('/');
-
-    await expect(page.getByRole('heading', { name: /saved match needs recovery/i })).toBeVisible();
+    await gotoHomeAndWaitForVisible(
+      page,
+      page.getByRole('heading', { name: /saved match needs recovery/i })
+    );
     await page.getByRole('button', { name: /reset and continue/i }).click();
 
     await expect(page).toHaveURL('/');
@@ -59,9 +181,7 @@ test.describe('@edge-case @setup @active-match @match-end Persistence recovery',
   test('shows the schema-mismatch notice only once after auto-reset', async ({ page }) => {
     await seedSchemaMismatchRecord(page);
 
-    await page.goto('/');
-
-    await expect(page.getByText(/saved match was reset/i)).toBeVisible();
+    await gotoHomeAndWaitForVisible(page, page.getByText(/saved match was reset/i));
     await expectCurrentMatchCleared(page);
 
     await page.reload();

--- a/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
+++ b/src/components/ActiveMatchScreen/ActiveMatchScreen.tsx
@@ -153,8 +153,18 @@ export function ActiveMatchScreen({
   const team2Name =
     resolvedTeam2Name === 'team-2' ? t('setup.firstServer.team2') : resolvedTeam2Name;
 
-  const { scoreDisplay, activeSetIndex, sideSwitch, servingTeam, servingPlayerNumber } = derived;
+  const {
+    scoreDisplay,
+    activeSetIndex,
+    sideSwitch,
+    servingTeam,
+    servingPlayerNumber,
+    isScoreboardMirrored
+  } = derived;
   const showServingIndicator = setup.servingIndicatorEnabled;
+  const visualTeamOrder = isScoreboardMirrored
+    ? (['team-2', 'team-1'] as const)
+    : (['team-1', 'team-2'] as const);
 
   useMatchAnnouncements({
     projection: snapshot.projection,
@@ -438,6 +448,21 @@ export function ActiveMatchScreen({
   );
   const isUndoTeam1Disabled = isLoading || !canUndoTeam1;
   const isUndoTeam2Disabled = isLoading || !canUndoTeam2;
+  const teamColumns = visualTeamOrder.map((teamId) => {
+    const isTeam1 = teamId === 'team-1';
+
+    return {
+      teamId,
+      teamName: isTeam1 ? team1Name : team2Name,
+      score: getTeamScore(teamId),
+      isServing: servingTeam === teamId,
+      servingPlayerNumber: servingTeam === teamId ? servingPlayerNumber : null,
+      onClick: isTeam1 ? handleScoreTeam1 : handleScoreTeam2,
+      onRevert: isTeam1 ? handleRevertTeam1 : handleRevertTeam2,
+      isUndoDisabled: isTeam1 ? isUndoTeam1Disabled : isUndoTeam2Disabled,
+      revertButtonClass: isTeam1 ? styles.revertButtonTeam1 : styles.revertButtonTeam2
+    };
+  });
 
   const headerContent = useMemo(
     () => (
@@ -495,57 +520,37 @@ export function ActiveMatchScreen({
         data-controls-hidden={shouldHideControls ? 'true' : undefined}
       >
         <div className={styles.scorePanel}>
-          <div className={styles.teamColumn}>
-            <TeamPanel
-              teamId="team-1"
-              teamName={team1Name}
-              score={getTeamScore('team-1')}
-              isServing={servingTeam === 'team-1'}
-              servingPlayerNumber={servingTeam === 'team-1' ? servingPlayerNumber : null}
-              showServingIndicator={showServingIndicator}
-              onClick={handleScoreTeam1}
-              disabled={isLoading || isMatchCompleted}
-            />
-            <button
-              type="button"
-              className={cn(styles.revertButton, styles.revertButtonTeam1)}
-              onClick={handleRevertTeam1}
-              disabled={isUndoTeam1Disabled}
-              data-testid="revert-button-team-1"
-              data-inactivity-ignore=""
-            >
-              {t('match.actions.revertPoint')}
-            </button>
-          </div>
-
-          <div className={styles.teamColumn}>
-            <TeamPanel
-              teamId="team-2"
-              teamName={team2Name}
-              score={getTeamScore('team-2')}
-              isServing={servingTeam === 'team-2'}
-              servingPlayerNumber={servingTeam === 'team-2' ? servingPlayerNumber : null}
-              showServingIndicator={showServingIndicator}
-              onClick={handleScoreTeam2}
-              disabled={isLoading || isMatchCompleted}
-            />
-            <button
-              type="button"
-              className={cn(styles.revertButton, styles.revertButtonTeam2)}
-              onClick={handleRevertTeam2}
-              disabled={isUndoTeam2Disabled}
-              data-testid="revert-button-team-2"
-              data-inactivity-ignore=""
-            >
-              {t('match.actions.revertPoint')}
-            </button>
-          </div>
+          {teamColumns.map((teamColumn) => (
+            <div key={teamColumn.teamId} className={styles.teamColumn}>
+              <TeamPanel
+                teamId={teamColumn.teamId}
+                teamName={teamColumn.teamName}
+                score={teamColumn.score}
+                isServing={teamColumn.isServing}
+                servingPlayerNumber={teamColumn.servingPlayerNumber}
+                showServingIndicator={showServingIndicator}
+                onClick={teamColumn.onClick}
+                disabled={isLoading || isMatchCompleted}
+              />
+              <button
+                type="button"
+                className={cn(styles.revertButton, teamColumn.revertButtonClass)}
+                onClick={teamColumn.onRevert}
+                disabled={teamColumn.isUndoDisabled}
+                data-testid={`revert-button-${teamColumn.teamId}`}
+                data-inactivity-ignore=""
+              >
+                {t('match.actions.revertPoint')}
+              </button>
+            </div>
+          ))}
 
           <div className={styles.setsOverlay}>
             <SetsCard
               sets={state.sets}
               currentSetIndex={activeSetIndex}
               onOpenHistory={handleOpenSetsHistory}
+              visualTeamOrder={visualTeamOrder}
             />
           </div>
         </div>
@@ -555,6 +560,7 @@ export function ActiveMatchScreen({
           openToken={setsHistoryOpenToken}
           sets={state.sets}
           onClose={handleCloseSetsHistory}
+          visualTeamOrder={visualTeamOrder}
         />
 
         <SideSwitchPrompt

--- a/src/components/ActiveMatchScreen/SetsCard/SetsCard.tsx
+++ b/src/components/ActiveMatchScreen/SetsCard/SetsCard.tsx
@@ -2,7 +2,12 @@ import { useTranslation } from 'react-i18next';
 
 import type { MatchSetState } from '@/core/match/types';
 
-import { getCurrentSet, getSetDisplayScore } from '../sets-history';
+import {
+  DEFAULT_VISUAL_TEAM_ORDER,
+  getCurrentSet,
+  getSetDisplayScore,
+  type VisualTeamOrder
+} from '../sets-history';
 
 import styles from './SetsCard.module.css';
 
@@ -10,16 +15,22 @@ interface SetsCardProps {
   sets: MatchSetState[];
   currentSetIndex: number | null;
   onOpenHistory?: () => void;
+  visualTeamOrder?: VisualTeamOrder;
 }
 
 /**
  * SetsCard component - compact trigger showing current set score only.
  */
-export function SetsCard({ sets, currentSetIndex, onOpenHistory }: SetsCardProps) {
+export function SetsCard({
+  sets,
+  currentSetIndex,
+  onOpenHistory,
+  visualTeamOrder = DEFAULT_VISUAL_TEAM_ORDER
+}: SetsCardProps) {
   const { t } = useTranslation();
 
   const currentSet = getCurrentSet(sets, currentSetIndex);
-  const currentScore = getSetDisplayScore(currentSet);
+  const currentScore = getSetDisplayScore(currentSet, visualTeamOrder);
 
   const cardContent = (
     <>

--- a/src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx
+++ b/src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx
@@ -13,7 +13,12 @@ import { SetScoreValue } from '@/components/SetScoreValue/SetScoreValue';
 import { getSetSummaryScoreParts } from '@/core/match/set-summary';
 import type { MatchSetState } from '@/core/match/types';
 
-import { getSetsWonScore } from '../sets-history';
+import {
+  DEFAULT_VISUAL_TEAM_ORDER,
+  getSetsWonScore,
+  reorderVisualTeamScore,
+  type VisualTeamOrder
+} from '../sets-history';
 
 import styles from './SetsHistoryModal.module.css';
 
@@ -23,6 +28,7 @@ interface SetsHistoryModalProps {
   sets: MatchSetState[];
   onClose: () => void;
   autoCloseDelay?: number;
+  visualTeamOrder?: VisualTeamOrder;
 }
 
 type DialogBackdropRenderProps = Parameters<
@@ -37,11 +43,12 @@ export function SetsHistoryModal({
   openToken,
   sets,
   onClose,
-  autoCloseDelay = 30000
+  autoCloseDelay = 30000,
+  visualTeamOrder = DEFAULT_VISUAL_TEAM_ORDER
 }: SetsHistoryModalProps) {
   const { t } = useTranslation();
   const portalContainerRef = useRef<HTMLDivElement | null>(null);
-  const setsWonScore = getSetsWonScore(sets);
+  const setsWonScore = getSetsWonScore(sets, visualTeamOrder);
   const title = t('match.sets.overallSetsScoreHeadline', {
     team1: setsWonScore['team-1'],
     team2: setsWonScore['team-2']
@@ -70,7 +77,7 @@ export function SetsHistoryModal({
       sets
         .filter((set) => set.completed)
         .map((set) => {
-          const setScore = getSetSummaryScoreParts(set);
+          const setScore = reorderVisualTeamScore(getSetSummaryScoreParts(set), visualTeamOrder);
 
           return {
             setNumber: set.index,
@@ -78,7 +85,7 @@ export function SetsHistoryModal({
             team2: setScore['team-2']
           };
         }),
-    [sets]
+    [sets, visualTeamOrder]
   );
 
   const handleBackdropRender = useCallback(

--- a/src/components/ActiveMatchScreen/sets-history.ts
+++ b/src/components/ActiveMatchScreen/sets-history.ts
@@ -1,23 +1,23 @@
-import type { CompletedMatchSet, MatchSetState, TeamScore } from '@/core/match/types';
+import { getCompletedSetTiebreakPoints } from '@/core/match/helpers';
+import type { CompletedMatchSet, MatchSetState, MatchTeamId, TeamScore } from '@/core/match/types';
 
-type LegacyCompletedSuperTiebreakSetShape = {
-  game?: {
-    kind?: unknown;
-    points?: TeamScore<number>;
-  };
-};
+export type VisualTeamOrder = readonly [MatchTeamId, MatchTeamId];
+export const DEFAULT_VISUAL_TEAM_ORDER = ['team-1', 'team-2'] as const satisfies VisualTeamOrder;
 
 function getCompletedSuperTiebreakScore(set: CompletedMatchSet): TeamScore<number> {
-  if (set.tiebreakPoints !== null) {
-    return set.tiebreakPoints;
-  }
+  return getCompletedSetTiebreakPoints(set) ?? set.games;
+}
 
-  const legacyShape = set as MatchSetState & LegacyCompletedSuperTiebreakSetShape;
-  if (legacyShape.game?.kind === 'tiebreak' && legacyShape.game.points !== undefined) {
-    return legacyShape.game.points;
-  }
+export function reorderVisualTeamScore<Value>(
+  score: TeamScore<Value>,
+  visualTeamOrder: VisualTeamOrder
+): TeamScore<Value> {
+  const [leftTeamId, rightTeamId] = visualTeamOrder;
 
-  return set.games;
+  return {
+    'team-1': score[leftTeamId],
+    'team-2': score[rightTeamId]
+  };
 }
 
 export function getCurrentSet(
@@ -31,38 +31,46 @@ export function getCurrentSet(
   return sets[sets.length - 1] ?? null;
 }
 
-export function getSetDisplayScore(set: MatchSetState | null): TeamScore<number> {
+export function getSetDisplayScore(
+  set: MatchSetState | null,
+  visualTeamOrder: VisualTeamOrder = DEFAULT_VISUAL_TEAM_ORDER
+): TeamScore<number> {
   if (set === null) {
     return { 'team-1': 0, 'team-2': 0 };
   }
 
   if (set.completed) {
     if (set.mode === 'super-tiebreak') {
-      return getCompletedSuperTiebreakScore(set);
+      return reorderVisualTeamScore(getCompletedSuperTiebreakScore(set), visualTeamOrder);
     }
 
-    return set.games;
+    return reorderVisualTeamScore(set.games, visualTeamOrder);
   }
 
   if (set.mode === 'super-tiebreak' && set.game.kind === 'tiebreak') {
-    return set.game.points;
+    return reorderVisualTeamScore(set.game.points, visualTeamOrder);
   }
 
-  return set.games;
+  return reorderVisualTeamScore(set.games, visualTeamOrder);
 }
 
-export function getSetsWonScore(sets: MatchSetState[]): TeamScore<number> {
-  return sets.reduce<TeamScore<number>>(
-    (score, set) => {
+export function getSetsWonScore(
+  sets: MatchSetState[],
+  visualTeamOrder: VisualTeamOrder = DEFAULT_VISUAL_TEAM_ORDER
+): TeamScore<number> {
+  const aggregateScore = sets.reduce<TeamScore<number>>(
+    (accumulator, set) => {
       if (!set.completed || typeof set.winner !== 'string') {
-        return score;
+        return accumulator;
       }
 
-      score[set.winner] += 1;
-      return score;
+      accumulator[set.winner] += 1;
+      return accumulator;
     },
     { 'team-1': 0, 'team-2': 0 }
   );
+
+  return reorderVisualTeamScore(aggregateScore, visualTeamOrder);
 }
 
 export function getSetsHistoryAutoOpenSignature(sets: MatchSetState[]): string {

--- a/src/core/match/derived-state.ts
+++ b/src/core/match/derived-state.ts
@@ -14,6 +14,7 @@ import {
 import {
   createTeamScore,
   getCompletedSetCount,
+  getCompletedSetTiebreakPoints,
   getOpponentTeamId,
   getTotalScore,
   isInitialStandardGame,
@@ -116,25 +117,95 @@ function recordTiebreakServiceTurns(
   }
 }
 
-function getCompletedStandardGameCount(set: CompletedMatchSet): number {
+function getCompletedSetServiceGameCount(set: CompletedMatchSet): number {
+  if (set.mode === 'super-tiebreak') {
+    return 0;
+  }
+
   if (set.tiebreakPoints === null) {
     return getTotalScore(set.games);
   }
 
-  return set.mode === 'super-tiebreak' ? 0 : 12;
+  return 12;
+}
+
+function getCompletedSetSideSwitchGameCount(set: CompletedMatchSet): number {
+  if (set.mode === 'super-tiebreak') {
+    return 0;
+  }
+
+  return getTotalScore(set.games);
+}
+
+function getStandardSideSwitchCount(completedGames: number): number {
+  if (completedGames <= 0) {
+    return 0;
+  }
+
+  return Math.floor((completedGames + 1) / 2);
+}
+
+function getTiebreakSideSwitchCount(pointsPlayed: number): number {
+  if (pointsPlayed <= 0) {
+    return 0;
+  }
+
+  return Math.floor(pointsPlayed / 6);
+}
+
+function getCompletedSetSideSwitchCount(set: CompletedMatchSet): number {
+  const completedGames = getCompletedSetSideSwitchGameCount(set);
+  const tiebreakPointsPlayed = getTotalScore(
+    getCompletedSetTiebreakPoints(set) ?? createTeamScore(0, 0)
+  );
+
+  return (
+    getStandardSideSwitchCount(completedGames) + getTiebreakSideSwitchCount(tiebreakPointsPlayed)
+  );
+}
+
+function getActiveSetSideSwitchCount(set: ActiveMatchSet): number {
+  const completedGames = getTotalScore(set.games);
+  const tiebreakPointsPlayed = set.game.kind === 'tiebreak' ? getTotalScore(set.game.points) : 0;
+
+  return (
+    getStandardSideSwitchCount(completedGames) + getTiebreakSideSwitchCount(tiebreakPointsPlayed)
+  );
+}
+
+function getMatchSideSwitchCount(state: MatchState): number {
+  const completedSetSwitchCount = getCompletedSets(state).reduce(
+    (count, set) => count + getCompletedSetSideSwitchCount(set),
+    0
+  );
+  const activeSet = getActiveSet(state);
+
+  return completedSetSwitchCount + (activeSet ? getActiveSetSideSwitchCount(activeSet) : 0);
+}
+
+function isScoreboardMirrored(setup: MatchSetup, state: MatchState): boolean {
+  if (!setup.sideSwitchPrompts) {
+    return false;
+  }
+
+  return getMatchSideSwitchCount(state) % 2 === 1;
 }
 
 function getServiceTurnCountsBeforeActiveTurn(state: MatchState): TeamScore<number> {
   const counts = createTeamScore(0, 0);
 
   for (const set of getCompletedSets(state)) {
-    recordStandardServiceTurns(counts, set.firstServer, getCompletedStandardGameCount(set));
+    const completedServiceGames = getCompletedSetServiceGameCount(set);
 
-    if (set.tiebreakPoints !== null) {
+    recordStandardServiceTurns(counts, set.firstServer, completedServiceGames);
+
+    const completedSetTiebreakPoints = getCompletedSetTiebreakPoints(set);
+
+    if (completedSetTiebreakPoints !== null) {
       recordTiebreakServiceTurns(
         counts,
-        toggleServer(set.firstServer, getCompletedStandardGameCount(set)),
-        getTotalScore(set.tiebreakPoints),
+        toggleServer(set.firstServer, completedServiceGames),
+        getTotalScore(completedSetTiebreakPoints),
         true
       );
     }
@@ -195,7 +266,7 @@ function getServingPlayerNumberForTeam(
 }
 
 export function getNextSetFirstServer(set: CompletedMatchSet): MatchTeamId {
-  if (set.tiebreakPoints !== null) {
+  if (getCompletedSetTiebreakPoints(set) !== null) {
     const gamesBeforeTiebreak = set.mode === 'super-tiebreak' ? 0 : 12;
     const openingServer = toggleServer(set.firstServer, gamesBeforeTiebreak);
 
@@ -250,16 +321,21 @@ function getSideSwitchState(setup: MatchSetup, state: MatchState): MatchSideSwit
 
   if (activeSet.game.kind === 'tiebreak') {
     const pointsPlayed = getTotalScore(activeSet.game.points);
+    const shouldPrompt = getTiebreakSideSwitchCount(pointsPlayed) > 0 && pointsPlayed % 6 === 0;
 
     return {
-      shouldPrompt: pointsPlayed > 0 && pointsPlayed % 6 === 0,
-      reason: pointsPlayed > 0 && pointsPlayed % 6 === 0 ? 'tiebreak-interval' : null
+      shouldPrompt,
+      reason: shouldPrompt ? 'tiebreak-interval' : null
     };
   }
 
   const totalGames = getTotalScore(activeSet.games);
 
-  if (totalGames > 0 && totalGames % 2 === 1 && isInitialStandardGame(activeSet)) {
+  if (
+    isInitialStandardGame(activeSet) &&
+    getStandardSideSwitchCount(totalGames) > 0 &&
+    totalGames % 2 === 1
+  ) {
     return {
       shouldPrompt: true,
       reason: 'odd-games'
@@ -329,6 +405,7 @@ export function deriveMatchState(setup: MatchSetup, state: MatchState): MatchDer
     winner,
     canContinuePlaying: winner !== null && setup.setCap !== null,
     setsWon: getSetsWon(state),
+    isScoreboardMirrored: isScoreboardMirrored(setup, state),
     sideSwitch: getSideSwitchState(setup, state),
     scoreDisplay: getScoreDisplay(state)
   };

--- a/src/core/match/helpers.ts
+++ b/src/core/match/helpers.ts
@@ -1,4 +1,14 @@
-import type { ActiveMatchSet, CompletedMatchSet, MatchTeamId, TeamScore } from './types';
+import type {
+  ActiveMatchSet,
+  CompletedMatchSet,
+  MatchGameState,
+  MatchTeamId,
+  TeamScore
+} from './types';
+
+type LegacyCompletedSuperTiebreakSetShape = {
+  game?: MatchGameState;
+};
 
 export function createTeamScore<T>(teamOne: T, teamTwo: T): TeamScore<T> {
   return {
@@ -57,4 +67,22 @@ export function getCompletedSetCount(sets: CompletedMatchSet[]): TeamScore<numbe
     },
     createTeamScore(0, 0)
   );
+}
+
+export function getCompletedSetTiebreakPoints(set: CompletedMatchSet): TeamScore<number> | null {
+  if (set.tiebreakPoints !== null) {
+    return set.tiebreakPoints;
+  }
+
+  if (set.mode !== 'super-tiebreak') {
+    return null;
+  }
+
+  const legacyShape = set as CompletedMatchSet & LegacyCompletedSuperTiebreakSetShape;
+
+  if (legacyShape.game?.kind === 'tiebreak') {
+    return legacyShape.game.points;
+  }
+
+  return null;
 }

--- a/src/core/match/set-summary.ts
+++ b/src/core/match/set-summary.ts
@@ -1,3 +1,4 @@
+import { getCompletedSetTiebreakPoints } from './helpers';
 import type { CompletedMatchSet, MatchSetState, TeamScore } from './types';
 
 export interface SetSummaryScorePart {
@@ -27,8 +28,8 @@ function toStringScore(scores: TeamScore<number>): TeamScore<string> {
 }
 
 function getBaseSetSummaryScores(set: MatchSetState): TeamScore<number> {
-  if (set.completed && set.mode === 'super-tiebreak' && set.tiebreakPoints !== null) {
-    return set.tiebreakPoints;
+  if (set.completed && set.mode === 'super-tiebreak') {
+    return getCompletedSetTiebreakPoints(set) ?? set.games;
   }
 
   return set.games;

--- a/src/core/match/types.ts
+++ b/src/core/match/types.ts
@@ -161,6 +161,7 @@ export interface MatchDerivedState {
   winner: MatchWinner | null;
   canContinuePlaying: boolean;
   setsWon: TeamScore<number>;
+  isScoreboardMirrored: boolean;
   sideSwitch: MatchSideSwitchState;
   scoreDisplay: MatchScoreDisplay;
 }

--- a/test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx
+++ b/test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx
@@ -548,6 +548,63 @@ describe('ActiveMatchScreen', () => {
     expect(screen.container.querySelector('[data-testid^="serve-status-"]')).toBeNull();
   });
 
+  test('mirrors visual order and keeps it after dismissing the side-switch prompt', async () => {
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup({ sideSwitchPrompts: true })}
+        initialActions={winQuickGame('team-1')}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    expect(readVisualTeamOrder(screen)).toEqual(['team-panel-team-2', 'team-panel-team-1']);
+    await expect.element(screen.getByTestId('set-score-current')).toHaveTextContent('0-1');
+    await expect.element(screen.getByTestId('side-switch-prompt')).toBeInTheDocument();
+
+    await screen.getByRole('button', { name: 'Switched' }).click();
+
+    await vi.waitFor(() => {
+      expect(screen.container.querySelector('[data-testid="side-switch-prompt"]')).toBeNull();
+    });
+
+    expect(readVisualTeamOrder(screen)).toEqual(['team-panel-team-2', 'team-panel-team-1']);
+    await expect.element(screen.getByTestId('set-score-current')).toHaveTextContent('0-1');
+  });
+
+  test('uses mirrored visible columns for scoring while speech payload stays on real team ids', async () => {
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup({
+          servingIndicatorEnabled: true,
+          sideSwitchPrompts: true
+        })}
+        initialActions={winQuickGame('team-1')}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    await expect.element(getVisibleTeamPanel(screen, 0)).toHaveClass(teamPanelStyles.serving!);
+    await expect.element(getVisibleTeamPanel(screen, 1)).not.toHaveClass(teamPanelStyles.serving!);
+
+    await getVisibleTeamPanel(screen, 0).click();
+
+    await vi.waitFor(() => {
+      expect(readDisplayedScore(screen, 'team-1')).toBe('0');
+      expect(readDisplayedScore(screen, 'team-2')).toBe('15');
+    });
+
+    expect(mockSpeechAnnounce).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        eventType: 'point-scored',
+        team1Score: '0',
+        team2Score: '15',
+        servingTeam: 'team-2'
+      })
+    );
+  });
+
   test('does not highlight team panels when the serving indicator is disabled', async () => {
     const screen = await render(
       <ActiveMatchScreen
@@ -890,6 +947,34 @@ describe('ActiveMatchScreen', () => {
       expect(readDisplayedScore(screen, 'team-1')).toBe('0');
       expect(readDisplayedScore(screen, 'team-2')).toBe('15');
     });
+  });
+
+  test('uses mirrored visible revert button and recomputes tiebreak mirror parity after undo', async () => {
+    const screen = await render(
+      <ActiveMatchScreen
+        matchId="test-match"
+        initialSetup={createTestSetup({
+          format: 'best-of-1',
+          sideSwitchPrompts: true
+        })}
+        initialActions={[
+          ...reachSixAll(),
+          ...scorePoints('team-1', 'team-2', 'team-1', 'team-2', 'team-1', 'team-2')
+        ]}
+        startedAt={defaultStartedAt}
+      />
+    );
+
+    expect(readVisualTeamOrder(screen)).toEqual(['team-panel-team-2', 'team-panel-team-1']);
+
+    await getVisibleRevertButton(screen, 0).click();
+
+    await vi.waitFor(() => {
+      expect(readDisplayedScore(screen, 'team-1')).toBe('3');
+      expect(readDisplayedScore(screen, 'team-2')).toBe('2');
+    });
+
+    expect(readVisualTeamOrder(screen)).toEqual(['team-panel-team-1', 'team-panel-team-2']);
   });
 
   test('loads saved remote bindings on mount', async () => {
@@ -1401,4 +1486,41 @@ function readDisplayedScore(
     screen.getByTestId(`team-panel-${teamId}`).element().querySelector('[aria-live="polite"]')
       ?.textContent ?? ''
   );
+}
+
+function readVisualTeamOrder(screen: Awaited<ReturnType<typeof render>>): string[] {
+  return Array.from(screen.container.querySelectorAll('[data-testid^="team-panel-"]')).map(
+    (element) => element.getAttribute('data-testid') ?? ''
+  );
+}
+
+function getVisibleTeamId(
+  screen: Awaited<ReturnType<typeof render>>,
+  columnIndex: number
+): 'team-1' | 'team-2' {
+  const testId = readVisualTeamOrder(screen)[columnIndex];
+
+  if (testId === 'team-panel-team-1') {
+    return 'team-1';
+  }
+
+  if (testId === 'team-panel-team-2') {
+    return 'team-2';
+  }
+
+  throw new Error(`Missing visible team panel at column ${String(columnIndex)}.`);
+}
+
+function getVisibleTeamPanel(
+  screen: Awaited<ReturnType<typeof render>>,
+  columnIndex: number
+): ReturnType<Awaited<ReturnType<typeof render>>['getByTestId']> {
+  return screen.getByTestId(`team-panel-${getVisibleTeamId(screen, columnIndex)}`);
+}
+
+function getVisibleRevertButton(
+  screen: Awaited<ReturnType<typeof render>>,
+  columnIndex: number
+): ReturnType<Awaited<ReturnType<typeof render>>['getByTestId']> {
+  return screen.getByTestId(`revert-button-${getVisibleTeamId(screen, columnIndex)}`);
 }

--- a/test/components/ActiveMatchScreen/SetsCard.browser.test.tsx
+++ b/test/components/ActiveMatchScreen/SetsCard.browser.test.tsx
@@ -112,4 +112,37 @@ describe('SetsCard', () => {
 
     await expect.element(screen.getByTestId('set-score-current')).toHaveTextContent('8-7');
   });
+
+  test('mirrors current set score and accessible label when visual order is swapped', async () => {
+    const sets: MatchSetState[] = [
+      {
+        index: 1,
+        mode: 'standard',
+        firstServer: 'team-1',
+        completed: false,
+        games: { 'team-1': 4, 'team-2': 5 },
+        game: {
+          kind: 'standard',
+          points: { 'team-1': 0, 'team-2': 0 },
+          advantageTeam: null
+        }
+      }
+    ];
+
+    const screen = await render(
+      <SetsCard
+        sets={sets}
+        currentSetIndex={0}
+        visualTeamOrder={['team-2', 'team-1']}
+        onOpenHistory={() => undefined}
+      />
+    );
+
+    await expect.element(screen.getByTestId('set-score-current')).toHaveTextContent('5-4');
+    await expect
+      .element(
+        screen.getByRole('button', { name: /open sets history\. current set score: 5 - 4/i })
+      )
+      .toBeInTheDocument();
+  });
 });

--- a/test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx
+++ b/test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx
@@ -164,4 +164,42 @@ describe('SetsHistoryModal', () => {
       .element(screen.getByTestId('sets-history-modal-list'))
       .toHaveTextContent('7(8) - 6(6)');
   });
+
+  test('mirrors headline and completed set rows when visual order is swapped', async () => {
+    const onClose = vi.fn<() => void>();
+    const screen = await render(
+      <SetsHistoryModal
+        isOpen
+        openToken={1}
+        sets={[
+          {
+            index: 1,
+            mode: 'standard',
+            firstServer: 'team-1',
+            completed: true,
+            winner: 'team-1',
+            games: { 'team-1': 6, 'team-2': 4 },
+            tiebreakPoints: null
+          },
+          {
+            index: 2,
+            mode: 'standard',
+            firstServer: 'team-2',
+            completed: true,
+            winner: 'team-1',
+            games: { 'team-1': 7, 'team-2': 6 },
+            tiebreakPoints: { 'team-1': 8, 'team-2': 6 }
+          }
+        ]}
+        onClose={onClose}
+        visualTeamOrder={['team-2', 'team-1']}
+      />
+    );
+
+    await expect.element(screen.getByRole('heading', { name: /0 - 2/ })).toBeInTheDocument();
+    await expect.element(screen.getByTestId('sets-history-modal-list')).toHaveTextContent('4 - 6');
+    await expect
+      .element(screen.getByTestId('sets-history-modal-list'))
+      .toHaveTextContent('6(6) - 7(8)');
+  });
 });

--- a/test/components/ActiveMatchScreen/sets-history.test.ts
+++ b/test/components/ActiveMatchScreen/sets-history.test.ts
@@ -3,11 +3,19 @@ import { describe, expect, test } from 'vitest';
 import {
   getSetDisplayScore,
   getSetsHistoryAutoOpenSignature,
-  getSetsWonScore
+  getSetsWonScore,
+  reorderVisualTeamScore
 } from '@/components/ActiveMatchScreen/sets-history';
 import type { MatchSetState } from '@/core/match/types';
 
 describe('sets-history display score', () => {
+  test('reorders scores into the current visual team order', () => {
+    expect(reorderVisualTeamScore({ 'team-1': 6, 'team-2': 4 }, ['team-2', 'team-1'])).toEqual({
+      'team-1': 4,
+      'team-2': 6
+    });
+  });
+
   test('uses tiebreak points for completed super-tiebreak sets when available', () => {
     const set: MatchSetState = {
       index: 3,
@@ -53,6 +61,26 @@ describe('sets-history display score', () => {
 
     expect(getSetDisplayScore(set)).toEqual({ 'team-1': 1, 'team-2': 0 });
   });
+
+  test('mirrors current set display score when visual order is swapped', () => {
+    const set: MatchSetState = {
+      index: 2,
+      mode: 'standard',
+      firstServer: 'team-2',
+      completed: false,
+      games: { 'team-1': 5, 'team-2': 2 },
+      game: {
+        kind: 'standard',
+        points: { 'team-1': 0, 'team-2': 0 },
+        advantageTeam: null
+      }
+    };
+
+    expect(getSetDisplayScore(set, ['team-2', 'team-1'])).toEqual({
+      'team-1': 2,
+      'team-2': 5
+    });
+  });
 });
 
 describe('sets-history aggregate score', () => {
@@ -91,6 +119,49 @@ describe('sets-history aggregate score', () => {
     ];
 
     expect(getSetsWonScore(sets)).toEqual({ 'team-1': 1, 'team-2': 1 });
+  });
+
+  test('reorders aggregate sets won score into the current visual order', () => {
+    const sets: MatchSetState[] = [
+      {
+        index: 1,
+        mode: 'standard',
+        firstServer: 'team-1',
+        completed: true,
+        winner: 'team-1',
+        games: { 'team-1': 6, 'team-2': 4 },
+        tiebreakPoints: null
+      },
+      {
+        index: 2,
+        mode: 'standard',
+        firstServer: 'team-2',
+        completed: true,
+        winner: 'team-1',
+        games: { 'team-1': 6, 'team-2': 3 },
+        tiebreakPoints: null
+      }
+    ];
+
+    expect(getSetsWonScore(sets, ['team-2', 'team-1'])).toEqual({
+      'team-1': 0,
+      'team-2': 2
+    });
+  });
+
+  test('reorders completed set summary parts into the current visual order', () => {
+    expect(
+      reorderVisualTeamScore(
+        {
+          'team-1': { score: '7', tiebreakPoints: '8' },
+          'team-2': { score: '6', tiebreakPoints: '6' }
+        },
+        ['team-2', 'team-1']
+      )
+    ).toEqual({
+      'team-1': { score: '6', tiebreakPoints: '6' },
+      'team-2': { score: '7', tiebreakPoints: '8' }
+    });
   });
 });
 

--- a/test/core/match/serve-derived-state.test.ts
+++ b/test/core/match/serve-derived-state.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, test } from 'vitest';
 
 import { continueMatch, projectMatch } from '@/core/match/replay';
 import {
+  deriveMatchState,
   getActiveSet,
   getNextSetFirstServer,
   getServingPlayerNumber,
   getServingTeam
 } from '@/core/match/derived-state';
+import type { MatchState } from '@/core/match/types';
 
 import {
   createTestSetup,
@@ -16,6 +18,10 @@ import {
   winQuickGame,
   winQuickSet
 } from './test-helpers';
+
+function createCompletedStandardTiebreakSetActions(winner: 'team-1' | 'team-2') {
+  return [...reachSixAll(), ...repeatAction(winner, 7)];
+}
 
 describe('serve rotation and derived state', () => {
   test('alternates the serving team by completed game', () => {
@@ -119,6 +125,115 @@ describe('serve rotation and derived state', () => {
       shouldPrompt: true,
       reason: 'tiebreak-interval'
     });
+    expect(afterOneGame.derived.isScoreboardMirrored).toBe(true);
+    expect(duringTiebreak.derived.isScoreboardMirrored).toBe(true);
+  });
+
+  test('derives mirrored scoreboard parity cumulatively across set boundaries and undo states', () => {
+    const setup = createTestSetup({
+      sideSwitchPrompts: true,
+      format: 'best-of-3'
+    });
+
+    const afterSixLoveSet = projectMatch(setup, winQuickSet('team-1'));
+    const afterSixLovePlusOneGame = projectMatch(setup, [
+      ...winQuickSet('team-1'),
+      ...winQuickGame('team-2')
+    ]);
+    const afterSevenFiveSet = projectMatch(setup, [
+      ...Array.from({ length: 5 }, () => winQuickGame('team-1')).flat(),
+      ...Array.from({ length: 5 }, () => winQuickGame('team-2')).flat(),
+      ...winQuickGame('team-1'),
+      ...winQuickGame('team-1')
+    ]);
+
+    expect(afterSixLoveSet.derived.isScoreboardMirrored).toBe(true);
+    expect(afterSixLovePlusOneGame.derived.isScoreboardMirrored).toBe(false);
+    expect(afterSevenFiveSet.derived.isScoreboardMirrored).toBe(false);
+  });
+
+  test.each([
+    ['team-1', '7-6'],
+    ['team-2', '6-7']
+  ] as const)(
+    'prompts next set start after a completed %s standard tiebreak set (%s) and keeps parity unmirrored',
+    (winner, _completedScore) => {
+      const setup = createTestSetup({
+        sideSwitchPrompts: true,
+        format: 'best-of-3'
+      });
+      const projection = projectMatch(setup, createCompletedStandardTiebreakSetActions(winner));
+
+      expect(projection.derived.activeSetIndex).toBe(2);
+      expect(projection.derived.sideSwitch).toEqual({
+        shouldPrompt: true,
+        reason: 'odd-games'
+      });
+      expect(projection.derived.isScoreboardMirrored).toBe(false);
+      expect(projection.state.sets[0]).toMatchObject({
+        completed: true,
+        games: winner === 'team-1' ? { 'team-1': 7, 'team-2': 6 } : { 'team-1': 6, 'team-2': 7 }
+      });
+    }
+  );
+
+  test('disables mirrored scoreboard parity when side-switch prompts are off', () => {
+    const setup = createTestSetup({
+      sideSwitchPrompts: false,
+      format: 'best-of-1'
+    });
+    const projection = projectMatch(setup, [
+      ...reachSixAll(),
+      ...scorePoints('team-1', 'team-2', 'team-1', 'team-2', 'team-1', 'team-2')
+    ]);
+
+    expect(projection.derived.sideSwitch).toEqual({
+      shouldPrompt: false,
+      reason: null
+    });
+    expect(projection.derived.isScoreboardMirrored).toBe(false);
+  });
+
+  test('recovers legacy completed super-tiebreak points for mirror parity', () => {
+    const setup = createTestSetup({
+      format: 'best-of-3',
+      sideSwitchPrompts: true
+    });
+    const state = {
+      actionCount: 6,
+      sets: [
+        {
+          index: 1,
+          mode: 'super-tiebreak',
+          firstServer: 'team-1',
+          completed: true,
+          winner: 'team-1',
+          games: { 'team-1': 0, 'team-2': 0 },
+          tiebreakPoints: null,
+          game: {
+            kind: 'tiebreak',
+            targetPoints: 11,
+            points: { 'team-1': 6, 'team-2': 0 }
+          }
+        },
+        {
+          index: 2,
+          mode: 'standard',
+          firstServer: 'team-2',
+          completed: false,
+          games: { 'team-1': 0, 'team-2': 0 },
+          game: {
+            kind: 'standard',
+            points: { 'team-1': 0, 'team-2': 0 },
+            advantageTeam: null
+          }
+        }
+      ]
+    } as MatchState;
+
+    const derived = deriveMatchState(setup, state);
+
+    expect(derived.isScoreboardMirrored).toBe(true);
   });
 
   test('prompts for the next set when the previous completed set had an odd total game count', () => {

--- a/test/core/match/set-summary.test.ts
+++ b/test/core/match/set-summary.test.ts
@@ -69,6 +69,25 @@ describe('set summary formatter', () => {
     expect(formatSetSummaryScore(set)).toBe('11 - 9');
   });
 
+  test('recovers legacy completed super tiebreak points from the stored game snapshot', () => {
+    const set = {
+      index: 3,
+      mode: 'super-tiebreak',
+      firstServer: 'team-1',
+      completed: true,
+      winner: 'team-1',
+      games: { 'team-1': 0, 'team-2': 0 },
+      tiebreakPoints: null,
+      game: {
+        kind: 'tiebreak',
+        points: { 'team-1': 11, 'team-2': 9 },
+        targetPoints: 11
+      }
+    } as MatchSetState;
+
+    expect(formatSetSummaryScore(set)).toBe('11 - 9');
+  });
+
   test('does not show completed tiebreak winner notation early for in-progress sets', () => {
     const set: MatchSetState = {
       index: 1,


### PR DESCRIPTION
## Summary

Mirrors the scoreboard team columns (left/right) when a side switch is due, so players always see their team in the correct physical position before switching ends. This prevents confusion during matches where teams need to switch sides at set intervals.

## What was added

### Core logic
- **`src/core/match/derived-state.ts`** — New `getMirroredTeams()` derived state that determines when team columns should be swapped based on the current set/game context and side-switch rules
- **`src/core/match/helpers.ts`** — Helper functions for side-switch detection and team mirroring calculations
- **`src/core/match/set-summary.ts`** — Updated set summary to support mirrored team display
- **`src/core/match/types.ts`** — Added `MirroredTeams` type for type-safe mirrored state

### UI components
- **`src/components/ActiveMatchScreen/ActiveMatchScreen.tsx`** — Applies team mirroring to the scoreboard layout so the correct team appears on the correct side
- **`src/components/ActiveMatchScreen/SetsCard/SetsCard.tsx`** — Mirrors set score columns when side switch is pending
- **`src/components/ActiveMatchScreen/SetsHistoryModal/SetsHistoryModal.tsx`** — Mirrors set history columns consistently
- **`src/components/ActiveMatchScreen/sets-history.ts`** — Updated sets history logic to account for mirrored teams

### Tests
- **`test/core/match/serve-derived-state.test.ts`** — 115 new assertions covering mirroring edge cases
- **`test/core/match/set-summary.test.ts`** — Tests for mirrored set summaries
- **`test/components/ActiveMatchScreen/ActiveMatchScreen.browser.test.tsx`** — Browser tests for mirrored scoreboard rendering
- **`test/components/ActiveMatchScreen/SetsCard.browser.test.tsx`** — SetsCard mirroring tests
- **`test/components/ActiveMatchScreen/SetsHistoryModal.browser.test.tsx`** — SetsHistoryModal mirroring tests
- **`test/components/ActiveMatchScreen/sets-history.test.ts`** — Unit tests for mirrored sets history

### E2E tests
- **`e2e/active-match.happy-path.spec.ts`** — Updated happy path to verify side-switch mirroring
- **`e2e/helpers/persistence.ts`** — Persistence helper updates for mirroring state
- **`e2e/persistence-recovery.edge-case.spec.ts`** — Edge case tests for mirroring after recovery

### Documentation
- **`docs/plan/Plan PBW-113 Mirror active match scoreboard when side switch is due.md`** — Implementation plan
- **`docs/development-logs/Task PBW-113 Mirror Active Match Scoreboard When Side Switch Is Due.md`** — Development log

## Test results

- ✅ 103 test files passed
- ✅ 1,143 tests passed
- ✅ Coverage: 89.37% statements, 81.47% branches, 89.42% functions, 89.8% lines
- ✅ All lint and format checks passed (oxlint + oxfmt)
- ✅ Pre-push hooks passed (full test suite + coverage thresholds)